### PR TITLE
Add BLOOM config with smart attention caches, fix minor issues

### DIFF
--- a/petals_local_parallel/slicer_wrapper.py
+++ b/petals_local_parallel/slicer_wrapper.py
@@ -136,7 +136,7 @@ def wrap_submodules(model: nn.Module, module_rules: dict, rank: int, world_size:
     with torch.no_grad():
         for name, module in model.named_modules():
             for pattern, rule in module_rules.items():
-                if re.search(pattern, name) is not None:
+                if re.search(pattern, name) is not None or pattern == name == '':
                     unique_wrappers[module] = ParallelLayerWrapper(module, rule, rank=rank, world_size=world_size)
 
     for parent in list(model.modules()):

--- a/petals_local_parallel/slicer_wrapper.py
+++ b/petals_local_parallel/slicer_wrapper.py
@@ -136,7 +136,7 @@ def wrap_submodules(model: nn.Module, module_rules: dict, rank: int, world_size:
     with torch.no_grad():
         for name, module in model.named_modules():
             for pattern, rule in module_rules.items():
-                if re.search(pattern, name) is not None or pattern == name == '':
+                if re.search(pattern, name) is not None:
                     unique_wrappers[module] = ParallelLayerWrapper(module, rule, rank=rank, world_size=world_size)
 
     for parent in list(model.modules()):

--- a/src/tensor_parallel/communications.py
+++ b/src/tensor_parallel/communications.py
@@ -42,7 +42,7 @@ class CollectiveOperation(CollectiveOpetationBase):
                 except Exception as e:
                     for i in range(self.world_size):
                         self.rank_outputs[i] = (None, e)
-            self.barrier.wait(5)
+            self.barrier.wait()
             result, exception = self.rank_outputs[rank]
             if exception:
                 raise exception

--- a/src/tensor_parallel/communications.py
+++ b/src/tensor_parallel/communications.py
@@ -62,12 +62,41 @@ class NCCLAllGather(CollectiveOperation):
         self.dim = dim
 
     def _nccl_allgather(self, *tensors: torch.Tensor):
+        tensor_lengths = tuple(x.shape[self.dim] for x in tensors)
+        needs_padding = len(set(tensor_lengths)) != 1
+        ndim = tensors[0].ndim
+        if needs_padding:
+            tensors = list(tensors)
+            max_length = max(tensor_lengths)
+            pad = [0] * (ndim * 2)
+            for i in range(len(tensors)):
+                if tensor_lengths[i] < max_length:
+                    pad[2 * (ndim - self.dim - 1) + 1] = max_length - tensor_lengths[i]
+                    # to understand the index [2 * ndim - dim ...], see F.pad documentation
+                    tensors[i] = torch.nn.functional.pad(tensors[i], pad)
+
         gathered_tensors = cross_device_ops.NCCLAllGatherFunction.apply(*tensors)
-        dim_indices = list(range(1, gathered_tensors[0].ndim))
-        dim_indices.insert(self.dim, 0)
-        concatenated_shape = list(tensors[0].shape)
-        concatenated_shape[self.dim] = -1
-        return tuple(output.permute(dim_indices).reshape(concatenated_shape) for output in gathered_tensors)
+
+        if not needs_padding:
+            dim_indices = list(range(1, gathered_tensors[0].ndim))
+            dim_indices.insert(self.dim, 0)
+            concatenated_shape = list(tensors[0].shape)
+            concatenated_shape[self.dim] = -1
+            return tuple(output.permute(dim_indices).reshape(concatenated_shape) for output in gathered_tensors)
+        else:
+            # restore original tensor lengths by slicing off padding
+            gathered_tensor_slices = []
+            for i, tensor_length in enumerate(tensor_lengths):
+                slices_i = [slice(None) for _ in range(ndim + 1)]
+                slices_i[0] = i  # select i-th element from gathered tensors
+                slices_i[self.dim + 1] = slice(0, tensor_length)
+                gathered_tensor_slices.append(tuple(slices_i))
+
+            gathered_tensors = tuple(
+                torch.cat([gathered_tensor[slices_i] for slices_i in gathered_tensor_slices], dim=self.dim)
+                for gathered_tensor in gathered_tensors
+            )
+            return gathered_tensors
 
 
 class AllReduce(CollectiveOpetationBase):

--- a/src/tensor_parallel/slicer_wrapper.py
+++ b/src/tensor_parallel/slicer_wrapper.py
@@ -249,9 +249,12 @@ def process_output(
     output, output_actions: Dict[Arg, Callable[[torch.Tensor, int], torch.Tensor]], *, rank: int, world_size: int
 ):
     if isinstance(output, torch.Tensor):
-        return process_output([output], output_actions, rank=rank, world_size=world_size)[0]
+        return process_output({0: output}, output_actions, rank=rank, world_size=world_size)[0]
+    if isinstance(output, Sequence):
+        output_dict = process_output(dict(enumerate(output)), output_actions, rank=rank, world_size=world_size)
+        return type(output)((output_dict[i] for i in range(len(output))))
     for target, action in output_actions.items():
-        output[target] = apply_action(output[target], action, rank=rank, world_size=world_size)
+        output[target] = apply_action(output.get(target), action, rank=rank, world_size=world_size)
     return output
 
 

--- a/src/tensor_parallel/slicer_wrapper.py
+++ b/src/tensor_parallel/slicer_wrapper.py
@@ -137,7 +137,7 @@ class Config:
 def find_matching_actions(action_type: str, name: str, rules: ModuleRules) -> Dict[Arg, Action]:
     found_actions = {}
     for pattern, actions_for_pattern in rules.items():
-        if pattern.search(name) is not None:
+        if pattern.search(name) is not None or pattern == name == '':
             for key, action in actions_for_pattern.items():
                 if isinstance(key, str) and key.strip().isdigit():
                     key = int(key)  # canonoicalize int keys
@@ -215,7 +215,7 @@ def process_state_(module: nn.Module, config: Config, *, rank: int, world_size: 
     unused_patterns = set(config.state_rules.keys())
     for name, param in chain(module.named_parameters(), module.named_buffers()):
         for pattern, action in config.state_rules.items():
-            if pattern.search(name) is not None:
+            if pattern.search(name) is not None or pattern == name == '':
                 param.data = apply_action(param.data, action, rank=rank, world_size=world_size).clone()
                 # note: .clone is required so that the resulting parameter owns its storage
                 unused_patterns.discard(pattern)

--- a/src/tensor_parallel/slicer_wrapper.py
+++ b/src/tensor_parallel/slicer_wrapper.py
@@ -29,6 +29,8 @@ ModuleRules = Dict[Pattern, Dict[Arg, Action]]  # module rules are pattern-match
 logger = logging.getLogger(__file__)
 
 
+TENSOR_PARALLEL_USE_NATIVE = bool(os.environ.get("TENSOR_PARALLEL_USE_NATIVE"))
+
 @dataclasses.dataclass
 class Config:
     state_rules: StateRules
@@ -176,7 +178,7 @@ def create_collective_ops(rules: dict, devices: Sequence[torch.device]):
     all_cuda = all(device.type == "cuda" for device in devices)
     unique_output_transforms = {op for output_actions in rules.values() for op in output_actions.values()}
     transform_map = {}
-    if all_cuda and not os.environ.get("TENSOR_PARALLEL_USE_NATIVE"):
+    if all_cuda and not TENSOR_PARALLEL_USE_NATIVE:
         make_allreduce, make_allgather = NCCLAllReduce, NCCLAllGather
     else:
         make_allreduce = partial(

--- a/src/tensor_parallel/slicer_wrapper.py
+++ b/src/tensor_parallel/slicer_wrapper.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__file__)
 
 TENSOR_PARALLEL_USE_NATIVE = bool(os.environ.get("TENSOR_PARALLEL_USE_NATIVE"))
 
+
 @dataclasses.dataclass
 class Config:
     state_rules: StateRules

--- a/src/tensor_parallel/slicer_wrapper.py
+++ b/src/tensor_parallel/slicer_wrapper.py
@@ -225,7 +225,7 @@ def process_state_(module: nn.Module, config: Config, *, rank: int, world_size: 
                 unused_patterns.discard(pattern)
 
     if unused_patterns:
-        logger.warning(f"The following patterns in state_rules were unused: {sorted(unused_patterns)}")
+        logger.warning(f"The following patterns in state_rules were unused: {[str(p) for p in unused_patterns]}")
 
 
 def process_attrs_(module: nn.Module, actions: Dict[Arg, str], rank: int, world_size: int):

--- a/src/tensor_parallel/slicer_wrapper.py
+++ b/src/tensor_parallel/slicer_wrapper.py
@@ -58,7 +58,8 @@ class Config:
                 assert module.max_norm is None or module.norm_type < 2
                 assert getattr(module, "bias", None) is None or module.bias.shape == module.embedding_dim
                 config.state_rules[name + ".weight"] = "split 1"
-                config.state_rules[name + ".bias"] = "split 0"
+                if hasattr(module, "bias"):
+                    config.state_rules[name + ".bias"] = "split 0"
                 config.output_rules[name] = {0: "gather -1"}
             elif isinstance(module, conv._ConvNd) and module.groups == 1:
                 shape = [module.out_channels, module.in_channels] + list(module.kernel_size)

--- a/src/tensor_parallel/slicer_wrapper.py
+++ b/src/tensor_parallel/slicer_wrapper.py
@@ -138,7 +138,7 @@ class Config:
 def find_matching_actions(action_type: str, name: str, rules: ModuleRules) -> Dict[Arg, Action]:
     found_actions = {}
     for pattern, actions_for_pattern in rules.items():
-        if pattern.search(name) is not None or pattern == name == '':
+        if pattern.search(name) is not None:
             for key, action in actions_for_pattern.items():
                 if isinstance(key, str) and key.strip().isdigit():
                     key = int(key)  # canonoicalize int keys
@@ -216,7 +216,7 @@ def process_state_(module: nn.Module, config: Config, *, rank: int, world_size: 
     unused_patterns = set(config.state_rules.keys())
     for name, param in chain(module.named_parameters(), module.named_buffers()):
         for pattern, action in config.state_rules.items():
-            if pattern.search(name) is not None or pattern == name == '':
+            if pattern.search(name) is not None:
                 param.data = apply_action(param.data, action, rank=rank, world_size=world_size).clone()
                 # note: .clone is required so that the resulting parameter owns its storage
                 unused_patterns.discard(pattern)

--- a/src/tensor_parallel/slicer_wrapper.py
+++ b/src/tensor_parallel/slicer_wrapper.py
@@ -116,7 +116,7 @@ class Config:
                 if child in unique_wrappers:
                     setattr(parent, child_name, unique_wrappers[child])
 
-        return shard
+        return unique_wrappers.get(shard, shard)  # wrap the root module if needed
 
     def _maybe_wrap_submodule(self, name: str, module: nn.Module, *, rank: int, world_size: int) -> nn.Module:
         """

--- a/src/tensor_parallel/slicer_wrapper.py
+++ b/src/tensor_parallel/slicer_wrapper.py
@@ -236,9 +236,7 @@ def process_input(input_actions: Dict[Arg, str], rank: int, world_size: int, *ar
     extended_kwargs = dict(kwargs)
     extended_kwargs.update(enumerate(args))
     for target, action in input_actions.items():
-        if not isinstance(extended_kwargs[target], torch.Tensor):
-            continue  # optional parameter is None or False
-        extended_kwargs[target] = apply_action(extended_kwargs[target], action, rank=rank, world_size=world_size)
+        extended_kwargs[target] = apply_action(extended_kwargs.get(target), action, rank=rank, world_size=world_size)
     args = [extended_kwargs.pop(i) for i in range(len(args))]
     return args, extended_kwargs
 

--- a/src/tensor_parallel/slicer_wrapper.py
+++ b/src/tensor_parallel/slicer_wrapper.py
@@ -131,8 +131,9 @@ class Config:
         attr_actions = find_matching_actions("attr", name, self.attr_rules)
         input_actions = find_matching_actions("input", name, self.input_rules)
         output_actions = find_matching_actions("output", name, self.output_rules)
-        if input_actions or output_actions:
+        if attr_actions:
             process_attrs_(module, attr_actions, rank=rank, world_size=world_size)
+        if input_actions or output_actions:
             module = _TensorParallelWrapper(module, input_actions, output_actions, rank=rank, world_size=world_size)
         return module
 

--- a/src/tensor_parallel/slicing_configs.py
+++ b/src/tensor_parallel/slicing_configs.py
@@ -1,0 +1,24 @@
+"""
+Optimized configs for selected models
+"""
+
+from transformers import BloomConfig
+
+
+def get_bloom_config(bloom_config: BloomConfig, devices: Sequence[torch.device]):
+    return Config(
+        state_rules={
+            ".*self_attention\.query_key_value\.(weight|bias)": "split 0",
+            ".*self_attention\.dense\.(weight|bias)": "split 0",
+            ".*mlp\.dense_h_to_4h\.(weight|bias)": "split 0",
+            ".*mlp\.dense_4h_to_h\.weight": "split 1",
+            ".*mlp\.dense_4h_to_h\.bias": "scale",
+        },
+        input_rules={".*self_attention\.query_key_value": {"layer_past": func}},
+        output_rules={
+            ".*self_attention\.query_key_value": {0: "gather -1"},
+            ".*self_attention\.dense": {0: "gather -1"},
+            ".*mlp\.dense_4h_to_h$": {0: "sum"},
+        },
+        attr_rules={},
+    )

--- a/src/tensor_parallel/slicing_configs.py
+++ b/src/tensor_parallel/slicing_configs.py
@@ -8,6 +8,7 @@ NB: some of these configs get fairly complicated in order to squeeze a bit of ex
 
 from transformers import BloomConfig
 
+
 def split_heads(tensor: torch.Tensor, *, dim: int, head_dim: int, rank: int, world_size: int):
     """Split a tensor along dim such that each part size is divisible by head_dim"""
     if dim < 0:

--- a/src/tensor_parallel/slicing_configs.py
+++ b/src/tensor_parallel/slicing_configs.py
@@ -1,5 +1,9 @@
 """
-Optimized configs for selected models
+Optimized configs for selected models. These configs are not necessary, but they can improve performance in some
+cases, e.g. training with very small batches or inference with long sequences.
+
+NB: some of these configs get fairly complicated in order to squeeze a bit of extra performance. When developing your
+  own config, you can get most of the performance benefits by using auto config -- and maybe splitting MLP layers.
 """
 
 from transformers import BloomConfig

--- a/src/tensor_parallel/slicing_configs.py
+++ b/src/tensor_parallel/slicing_configs.py
@@ -4,6 +4,16 @@ Optimized configs for selected models
 
 from transformers import BloomConfig
 
+def split_heads(tensor: torch.Tensor, *, dim: int, head_dim: int, rank: int, world_size: int):
+    """Split a tensor along dim such that each part size is divisible by head_dim"""
+    if dim < 0:
+        dim = (tensor.ndim + dim) % tensor.ndim
+    shape = list(tensor.shape)
+    shape[dim] //= head_dim
+    shape.insert(dim + 1, head_dim)
+    tensor_part = tensor.reshape(shape).tensor_split(world_size, dim=dim)[rank].flatten(dim, dim + 1)
+    return tensor_part
+
 
 def get_bloom_config(bloom_config: BloomConfig, devices: Sequence[torch.device]):
     return Config(

--- a/src/tensor_parallel/slicing_configs.py
+++ b/src/tensor_parallel/slicing_configs.py
@@ -5,12 +5,64 @@ cases, e.g. training with very small batches or inference with long sequences.
 NB: some of these configs get fairly complicated in order to squeeze a bit of extra performance. When developing your
   own config, you can get most of the performance benefits by using auto config -- and maybe splitting MLP layers.
 """
+from functools import partial
+from itertools import chain
+from typing import Sequence
 
+import torch
 from transformers import BloomConfig
 
+from tensor_parallel import Config
+from tensor_parallel.communications import CollectiveOperation
+from tensor_parallel.tensor_parallel import PerDeviceTensors
 
-def split_heads(tensor: torch.Tensor, *, dim: int, head_dim: int, rank: int, world_size: int):
+
+def get_bloom_config(model_config: BloomConfig, devices: Sequence[torch.device]) -> Config:
+    world_size = len(devices)
+    num_heads = model_config.n_head
+    head_dim = model_config.hidden_size // num_heads
+    gather_kv_across_ranks = CollectiveOperation(
+        world_size=world_size, func=lambda *kvs: [PerDeviceTensors(*chain(*kvs))] * world_size
+    )  # this operation ensures that we get attention cache for all heads on each device
+
+    select_kv_for_rank = lambda kvs, rank: (kvs[2 * rank], kvs[2 * rank + 1]) if kvs else None
+
+    _split_alibi = partial(split_alibi, num_heads=num_heads, world_size=world_size)
+
+    return Config(
+        state_rules={
+            r".*self_attention\.query_key_value\.(weight|bias)$": partial(
+                split_heads, dim=0, head_dim=head_dim * 3, world_size=world_size
+            ),
+            r".*self_attention\.dense\.weight$": partial(split_heads, dim=1, head_dim=head_dim, world_size=world_size),
+            r".*self_attention\.dense\.bias$": "scale",
+            r".*mlp\.dense_h_to_4h\.(weight|bias)$": "split 0",
+            r".*mlp\.dense_4h_to_h\.weight$": "split 1",
+            r".*mlp\.dense_4h_to_h\.bias$": "scale",
+            r".*word_embeddings.weight$": "split 1",
+            # note: ^-- lm_head.weight is tied with word_embeddings
+        },
+        input_rules={
+            r".*self_attention$": {"layer_past": select_kv_for_rank, "alibi": _split_alibi},
+            r".*lm_head$": {0: "split -1"},  # note: we need to split lm_head inputs because
+            # ... lm_head's weights (tied embeddings) are already split across input dimension
+        },
+        output_rules={
+            r".*self_attention$": {1: gather_kv_across_ranks},
+            r".*self_attention\.dense$": {0: "sum"},
+            r".*mlp\.dense_4h_to_h$": {0: "sum"},
+            r".*word_embeddings$": {0: "gather -1"},
+            r".*lm_head$": {0: "sum"},
+        },
+        attr_rules={r".*self_attention$": {"num_heads": partial(split_num_heads, world_size=world_size)}},
+    )
+
+
+def split_heads(tensor: torch.Tensor, *, dim: int, head_dim: int, rank: int, world_size: int, optional: bool = False):
     """Split a tensor along dim such that each part size is divisible by head_dim"""
+    if tensor is None and optional:
+        return None
+    assert tensor.shape[dim] % head_dim == 0, tensor.shape
     if dim < 0:
         dim = (tensor.ndim + dim) % tensor.ndim
     shape = list(tensor.shape)
@@ -20,20 +72,12 @@ def split_heads(tensor: torch.Tensor, *, dim: int, head_dim: int, rank: int, wor
     return tensor_part
 
 
-def get_bloom_config(bloom_config: BloomConfig, devices: Sequence[torch.device]):
-    return Config(
-        state_rules={
-            ".*self_attention\.query_key_value\.(weight|bias)": "split 0",
-            ".*self_attention\.dense\.(weight|bias)": "split 0",
-            ".*mlp\.dense_h_to_4h\.(weight|bias)": "split 0",
-            ".*mlp\.dense_4h_to_h\.weight": "split 1",
-            ".*mlp\.dense_4h_to_h\.bias": "scale",
-        },
-        input_rules={".*self_attention\.query_key_value": {"layer_past": func}},
-        output_rules={
-            ".*self_attention\.query_key_value": {0: "gather -1"},
-            ".*self_attention\.dense": {0: "gather -1"},
-            ".*mlp\.dense_4h_to_h$": {0: "sum"},
-        },
-        attr_rules={},
-    )
+def split_num_heads(num_heads: int, *, rank: int, world_size: int):
+    return torch.empty(num_heads, device="meta").tensor_split(world_size)[rank].numel()
+
+
+def split_alibi(alibi: torch.Tensor, *, rank: int, num_heads: int, world_size: int) -> torch.Tensor:
+    """split alibi tensor of shape [batch_size * num_heads, ...] over attention heads"""
+    alibi_expanded = alibi.reshape(-1, num_heads, *alibi.shape[1:])
+    alibi_part = alibi_expanded.tensor_split(world_size, dim=1)[rank]
+    return alibi_part.reshape(-1, *alibi.shape[1:])

--- a/src/tensor_parallel/tensor_parallel.py
+++ b/src/tensor_parallel/tensor_parallel.py
@@ -42,6 +42,8 @@ class TensorParallel(nn.Module):
             assert output_device in device_ids, f"Output device {output_device} not in {device_ids}"
             output_device_index = device_ids.index(output_device)
             del output_device
+        elif output_device_index is None:
+            output_device_index = 0
 
         self.module_shards = nn.ModuleList()
 

--- a/src/tensor_parallel/tensor_parallel.py
+++ b/src/tensor_parallel/tensor_parallel.py
@@ -44,17 +44,16 @@ class TensorParallel(nn.Module):
             del output_device
 
         self.module_shards = nn.ModuleList()
-        if device_ids is None or len(device_ids) <= 1:
-            self.module_shards.append(module)
-            self.device_ids = []
-            self.output_device_index = 0
-            return
 
         self.devices = device_ids
         self.output_device_index = output_device_index
         self.all_cuda = all(device.type == "cuda" for device in self.devices)
         self.device_ids = [_get_device_index(x, optional=True, allow_cpu=True) for x in device_ids]
         world_size = len(self.devices)
+
+        if len(device_ids) <= 1:
+            self.module_shards.append(module)
+            return
 
         if config is None:
             config = Config.get_default_config(module)

--- a/src/tensor_parallel/tensor_parallel.py
+++ b/src/tensor_parallel/tensor_parallel.py
@@ -14,11 +14,10 @@ from torch.cuda.amp import autocast
 from torch.nn.parallel import parallel_apply
 
 from tensor_parallel.cross_device_ops import broadcast_coalesced
-from tensor_parallel.slicer_wrapper import Config
+from tensor_parallel.slicer_wrapper import Config, TENSOR_PARALLEL_USE_NATIVE
 from tensor_parallel.utils import nested_flatten, nested_pack
 
 logger = logging.getLogger(__file__)
-TENSOR_PARALLEL_USE_NATIVE = bool(os.environ.get("TENSOR_PARALLEL_USE_NATIVE"))
 
 
 class TensorParallel(nn.Module):

--- a/src/tensor_parallel/tensor_parallel.py
+++ b/src/tensor_parallel/tensor_parallel.py
@@ -179,3 +179,17 @@ def canonicalize_device(device: Union[torch.device, str]) -> torch.device:
     if device.type == "cuda" and device.index is None:
         device = torch.device(device, index=0)
     return device
+
+
+class PerDeviceTensors:
+    """tensors located on different deviecs that will *not* be broadcasted when passed to TensorParallel.forward"""
+
+    def __init__(self, *tensors: torch.Tensor):
+        # note: this will not be broadcasted because broadcast_coalesced does not broadcast class properties
+        self.tensors = tuple(tensors)
+
+    def __getitem__(self, i: int):
+        return self.tensors[i]
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self.tensors})"

--- a/src/tensor_parallel/tensor_parallel.py
+++ b/src/tensor_parallel/tensor_parallel.py
@@ -50,14 +50,9 @@ class TensorParallel(nn.Module):
             return
 
         self.devices = device_ids
+        self.output_device_index = output_device_index
         self.all_cuda = all(device.type == "cuda" for device in self.devices)
         self.device_ids = [_get_device_index(x, optional=True, allow_cpu=True) for x in device_ids]
-        if output_all:
-            assert output_device is None, "output_device is ignored if output_all is set to True"
-            self.output_device_index = slice(None)
-        elif output_device.type == "cuda" and output_device.index is None:
-            output_device = torch.device(output_device.type, index=0)
-            self.output_device_index = self.devices.index(output_device) if output_device is not None else 0
         world_size = len(self.devices)
 
         if config is None:

--- a/src/tensor_parallel/tensor_parallel.py
+++ b/src/tensor_parallel/tensor_parallel.py
@@ -5,7 +5,7 @@ import logging
 import os
 import threading
 from contextlib import nullcontext
-from typing import Any, Optional, Sequence
+from typing import Any, Optional, Sequence, Union
 
 import torch
 from torch import nn
@@ -55,7 +55,7 @@ class TensorParallel(nn.Module):
         if output_all:
             assert output_device is None, "output_device is ignored if output_all is set to True"
             self.output_device_index = slice(None)
-        elif output_device.type == 'cuda' and output_device.index is None:
+        elif output_device.type == "cuda" and output_device.index is None:
             output_device = torch.device(output_device.type, index=0)
             self.output_device_index = self.devices.index(output_device) if output_device is not None else 0
         world_size = len(self.devices)
@@ -177,8 +177,9 @@ def get_a_var(obj):
                 return result
     return None
 
+
 def canonicalize_device(device: Union[torch.device, str]) -> torch.device:
     device = torch.device(device)
-    if device.type == 'cuda' and device.index is None:
+    if device.type == "cuda" and device.index is None:
         device = torch.device(device, index=0)
     return device

--- a/src/tensor_parallel/tensor_parallel.py
+++ b/src/tensor_parallel/tensor_parallel.py
@@ -33,7 +33,10 @@ class TensorParallel(nn.Module):
         super().__init__()
         original_params = sum(p.numel() for p in module.parameters())
         assert output_device is None or output_device_index is None, "please specify either device or index, not both"
+        if device_ids is None:
+            device_ids = _get_all_device_indices() if torch.cuda.is_available() else []
         device_ids = tuple(map(canonicalize_device, device_ids))
+
         if output_device is not None:
             output_device = canonicalize_device(output_device)
             assert output_device in device_ids, f"Output device {output_device} not in {device_ids}"
@@ -41,8 +44,6 @@ class TensorParallel(nn.Module):
             del output_device
 
         self.module_shards = nn.ModuleList()
-        if device_ids is None:
-            device_ids = _get_all_device_indices()
         if device_ids is None or len(device_ids) <= 1:
             self.module_shards.append(module)
             self.device_ids = []

--- a/src/tensor_parallel/tensor_parallel.py
+++ b/src/tensor_parallel/tensor_parallel.py
@@ -78,7 +78,7 @@ class TensorParallel(nn.Module):
         logger.log(
             log_level,
             f"Inefficiency warning: model has {original_params} params but shards have {params_per_shard} params. "
-            f"This means that each GPU uses {inefficiency_rate * 100:.3f}% extra memory for parameters",
+            f"This means that each device uses {inefficiency_rate * 100:.3f}% extra memory for parameters",
         )
 
     def forward(self, *args, **kwargs):

--- a/src/tensor_parallel/tensor_parallel.py
+++ b/src/tensor_parallel/tensor_parallel.py
@@ -14,7 +14,7 @@ from torch.cuda.amp import autocast
 from torch.nn.parallel import parallel_apply
 
 from tensor_parallel.cross_device_ops import broadcast_coalesced
-from tensor_parallel.slicer_wrapper import Config, TENSOR_PARALLEL_USE_NATIVE
+from tensor_parallel.slicer_wrapper import TENSOR_PARALLEL_USE_NATIVE, Config
 from tensor_parallel.utils import nested_flatten, nested_pack
 
 logger = logging.getLogger(__file__)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,4 +1,3 @@
-import random
 from typing import Tuple
 
 import pytest

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -1,0 +1,36 @@
+import pytest
+import torch
+import transformers
+
+from tensor_parallel import TensorParallel
+from tensor_parallel.slicing_configs import get_bloom_config
+
+
+@pytest.mark.parametrize("use_config", [False, True])
+@pytest.mark.parametrize("devices", [("cpu",) * 2, ("cpu",) * 3])
+def test_bloom_inference(use_config, devices, model_name="bigscience/bloom-560m"):
+    model_config = transformers.AutoConfig.from_pretrained(model_name)
+    model = transformers.AutoModelForCausalLM.from_pretrained(model_name, low_cpu_mem_usage=True).to(devices[0])
+
+    inp1 = torch.randint(1, 1000, size=(2, 3), device=devices[0])
+    inp2 = torch.randint(1, 1000, size=(2, 1), device=devices[0])
+    inp3 = torch.randint(1, 1000, size=(2, 2), device=devices[0])
+
+    out1_ref = model(inp1, use_cache=True, output_hidden_states=True)
+    out2_ref = model(inp2, use_cache=True, past_key_values=out1_ref.past_key_values)
+    out3_ref = model(inp3, use_cache=True, past_key_values=out2_ref.past_key_values)
+
+    tp_config = None
+    if use_config:
+        tp_config = get_bloom_config(model_config, devices)
+    model_tp = TensorParallel(model, devices, config=tp_config)
+    del model
+
+    out1 = model_tp(inp1, use_cache=True, output_hidden_states=True)
+    out2 = model_tp(inp2, use_cache=True, past_key_values=out1.past_key_values)
+    out3 = model_tp(inp3, use_cache=True, past_key_values=out2.past_key_values)
+
+    assert torch.allclose(out1_ref.hidden_states[-1], out1.hidden_states[-1], atol=3e-3)
+    assert torch.allclose(out1_ref.logits, out1.logits, atol=3e-3)
+    assert torch.allclose(out2_ref.logits, out2.logits, atol=3e-3)
+    assert torch.allclose(out3_ref.logits, out3.logits, atol=3e-3)


### PR DESCRIPTION
This pull request

- adds a (highly tuned) bloom config that stores attention caches on separate devices instead of just device 0
   - this is important for inference with long sequences, where passing all attention cache from device 0 would be longer than recomputing it
- fixes several issues that occur with the odd number of gpus (e.g. 3)