### PR TITLE
Reduce memory footprint when instantiating model

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = tensor_parallel
-version = 1.0.4
+version = 1.0.21
 author = Andrei Panferov and Yaroslav Lisnyak
 author_email = yalisnyak@nes.com
 description = Automatically shard your large model between multiple GPUs, works without torch.distributed

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = tensor_parallel
-version = 1.0.3
+version = 1.0.4
 author = Andrei Panferov and Yaroslav Lisnyak
 author_email = yalisnyak@nes.com
 description = Automatically shard your large model between multiple GPUs, works without torch.distributed

--- a/src/tensor_parallel/slicer_wrapper.py
+++ b/src/tensor_parallel/slicer_wrapper.py
@@ -123,7 +123,7 @@ class Config:
         }
         shard = deepcopy(module, memo=substitutes).to(device)
         # ^-- note: the memo=... above will replace all parameters and buffers with empty tensors
-        del module
+        del module, substitutes
 
         # convert parameters and buffers
         process_state_(shard, source_tensors, config, rank=rank, world_size=world_size)

--- a/src/tensor_parallel/slicer_wrapper.py
+++ b/src/tensor_parallel/slicer_wrapper.py
@@ -116,11 +116,18 @@ class Config:
         assert (
             len(list(module.children())) != 0
         ), "Please ensure module is a container (e.g. Sequential), not a single layer"
-        shard = deepcopy(module).to(device)
+        source_tensors = dict(chain(module.named_parameters(), module.named_buffers()))
+        substitutes = {
+            id(x): torch.empty([], dtype=x.dtype, device=x.device, requires_grad=x.requires_grad)
+            for x in source_tensors.values()
+        }
+        shard = deepcopy(module, memo=substitutes).to(device)
+        # ^-- note: the memo=... above will replace all parameters and buffers with empty tensors
         del module
 
         # convert parameters and buffers
-        process_state_(shard, config, rank=rank, world_size=world_size)
+        process_state_(shard, source_tensors, config, rank=rank, world_size=world_size)
+        del source_tensors
 
         # convert or wrap intermediate modules
         unique_wrappers = {}
@@ -237,15 +244,26 @@ def create_collective_ops(rules: dict, devices: Sequence[torch.device]):
 
 
 @torch.no_grad()
-def process_state_(module: nn.Module, config: Config, *, rank: int, world_size: int):
-    """Modify module parameters and/or buffers in-place"""
+def process_state_(
+    sharded_module: nn.Module, source_tensors: Dict[str, torch.Tensor], config: Config, *, rank: int, world_size: int
+):
+    """
+    Initialize sharded_module's parameters and buffers by applying prescribed rules to source_module's buffers
+    :param sharded_module: target module that will be modified in-place
+    :param source_tensors: original parameters and buffers on a source device
+    """
     unused_patterns = set(config.state_rules.keys())
-    for name, param in chain(module.named_parameters(), module.named_buffers()):
+    for name, state in chain(sharded_module.named_parameters(), sharded_module.named_buffers()):
         for pattern, action in config.state_rules.items():
             if pattern.search(name) is not None:
-                param.data = apply_action(param.data, action, rank=rank, world_size=world_size).clone()
-                # note: .clone is required so that the resulting parameter owns its storage
+                new_data = apply_action(source_tensors[name], action, rank=rank, world_size=world_size)
                 unused_patterns.discard(pattern)
+                break
+        else:
+            new_data = source_tensors[name]  # copy source parameter as is
+
+        state.data = new_data.clone().detach().to(state.device).requires_grad_(state.requires_grad)
+        # note: .clone is required so that the resulting parameter owns its storage
 
     if unused_patterns:
         logger.warning(f"The following patterns in state_rules were unused: {[str(p) for p in unused_patterns]}")

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -35,6 +35,8 @@ def test_embeds_and_linear(devices):
 @pytest.mark.parametrize("devices", [None, ("cpu",), ("cpu",) * 2, ("cpu",) * 3, ("cpu",) * 4])
 @pytest.mark.parametrize("extra_options", [{}, {"padding": "same"}, {"stride": 2}, {"dilation": 2}])
 def test_convs(devices, extra_options):
+    batchnorm_cls = (None, nn.BatchNorm1d, nn.BatchNorm2d, nn.BatchNorm3d)
+    # ^-- note: batchnorms test that tensor_parallel handles buffers (non-parameter state tensors) correctly
     for Conv, nd in (
         (nn.Conv1d, 1),
         (nn.Conv2d, 2),
@@ -47,6 +49,7 @@ def test_convs(devices, extra_options):
             continue  # unsupported by pytorch
         model = nn.Sequential(
             Conv(32, 64, kernel_size=(3,) * nd, **extra_options),
+            batchnorm_cls[nd](64),
             nn.ReLU(),
             Conv(64, 14, kernel_size=(3,) * nd, **extra_options),
         )


### PR DESCRIPTION
This PR gets rid of a phase where each device temporarily holds all model parameters during init.
It allows running larger models.


Tested: sharding a large layer between 2 gpus now allocates 50% of full module memory on each GPU

![image](https://user-images.githubusercontent.com/3491902/209451587-9439a45b-bb3b-4c02-944c-f38d2fdf82df.png)

![image](https://user-images.githubusercontent.com/3491902/209451573-40142222-0563-47c2-a933-230ccd965496.png)


Note: I failed to make this code work with meta devices and opted for zero-size tensors instead. The issue with meta devices is that they, to the best of my knowledge, offer no easy way to un-meta a tensor in-place when setting to a value.