### PR TITLE
Hotfix parameters and warnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ package_dir =
 packages = find:
 python_requires = >=3.7
 install_requires =
-    torch>=1.12
+    torch>=1.11
     transformers>=4.25.1
 [options.extras_require]
 dev =

--- a/src/tensor_parallel/pretrained_model.py
+++ b/src/tensor_parallel/pretrained_model.py
@@ -21,7 +21,7 @@ def find_predefined_tensor_parallel_config(
     device_ids = check_device_ids(device_ids)
     if len(model_config.architectures) != 1:
         logger.warning(
-            f"No tensor parallel config provided and model architectures list is ambigious: {model_config.architectures}. Using possible inefficient fallback"
+            f"No tensor parallel config provided and model architectures list is ambigious: {model_config.architectures}. Using automatic config"
         )
         return None
 
@@ -29,7 +29,7 @@ def find_predefined_tensor_parallel_config(
         return PREDEFINED_CONFIGS[model_config.architectures[0]](model_config, device_ids)
     except KeyError:
         logger.warning(
-            "No tensor parallel config provided and no predefined configs can be used. Using possible inefficient fallback"
+            "No tensor parallel config provided and no predefined configs can be used. Using automatic config"
         )
         return None
 

--- a/src/tensor_parallel/pretrained_model.py
+++ b/src/tensor_parallel/pretrained_model.py
@@ -29,7 +29,7 @@ def find_predefined_tensor_parallel_config(
         return PREDEFINED_CONFIGS[model_config.architectures[0]](model_config, device_ids)
     except KeyError:
         logger.warning(
-            "Using automatic config: o tensor parallel config provided and no predefined configs can be used"
+            "Using automatic config: no tensor parallel config provided and no predefined configs can be used"
         )
         return None
 

--- a/src/tensor_parallel/pretrained_model.py
+++ b/src/tensor_parallel/pretrained_model.py
@@ -21,7 +21,7 @@ def find_predefined_tensor_parallel_config(
     device_ids = check_device_ids(device_ids)
     if len(model_config.architectures) != 1:
         logger.warning(
-            f"No tensor parallel config provided and model architectures list is ambigious: {model_config.architectures}. Using automatic config"
+            f"Using automatic config: no tensor parallel config provided and model architectures list is ambigious: {model_config.architectures}"
         )
         return None
 
@@ -29,7 +29,7 @@ def find_predefined_tensor_parallel_config(
         return PREDEFINED_CONFIGS[model_config.architectures[0]](model_config, device_ids)
     except KeyError:
         logger.warning(
-            "No tensor parallel config provided and no predefined configs can be used. Using automatic config"
+            "Using automatic config: o tensor parallel config provided and no predefined configs can be used"
         )
         return None
 

--- a/src/tensor_parallel/slicer_wrapper.py
+++ b/src/tensor_parallel/slicer_wrapper.py
@@ -135,9 +135,9 @@ class Config:
             len(list(module.children())) != 0
         ), "Please ensure module is a container (e.g. Sequential), not a single layer"
         source_tensors = dict(chain(module.named_parameters(), module.named_buffers()))
-        _wrap_parameter = lambda x, buf: nn.Parameter(buf, x.requires_grad) if isinstance(x, nn.Parameter) else x
+        _maybe_parameter = lambda x, buf: nn.Parameter(buf, x.requires_grad) if isinstance(x, nn.Parameter) else x
         substitutes = {
-            id(x): _wrap_parameter(x, torch.empty([], dtype=x.dtype, device=x.device, requires_grad=x.requires_grad))
+            id(x): _maybe_parameter(x, torch.empty([], dtype=x.dtype, device=x.device, requires_grad=x.requires_grad))
             for x in source_tensors.values()
         }
         shard = deepcopy(module, memo=substitutes).to(device)

--- a/src/tensor_parallel/slicer_wrapper.py
+++ b/src/tensor_parallel/slicer_wrapper.py
@@ -135,8 +135,9 @@ class Config:
             len(list(module.children())) != 0
         ), "Please ensure module is a container (e.g. Sequential), not a single layer"
         source_tensors = dict(chain(module.named_parameters(), module.named_buffers()))
+        _wrap_parameter = lambda x, buf: nn.Parameter(buf, x.requires_grad) if isinstance(x, nn.Parameter) else x
         substitutes = {
-            id(x): torch.empty([], dtype=x.dtype, device=x.device, requires_grad=x.requires_grad)
+            id(x): _wrap_parameter(x, torch.empty([], dtype=x.dtype, device=x.device, requires_grad=x.requires_grad))
             for x in source_tensors.values()
         }
         shard = deepcopy(module, memo=substitutes).to(device)

--- a/src/tensor_parallel/training_utils.py
+++ b/src/tensor_parallel/training_utils.py
@@ -1,3 +1,0 @@
-"""
-Auxiliary functions used to deal with non-sharded parameters when training
-"""

--- a/src/tensor_parallel/training_utils.py
+++ b/src/tensor_parallel/training_utils.py
@@ -1,0 +1,3 @@
+"""
+Auxiliary functions used to deal with non-sharded parameters when training
+"""


### PR DESCRIPTION
Previously, our TP models would replace all nn.Parameters with tensors. They would still gather normally, but the type would be wrong

![image](https://user-images.githubusercontent.com/3491902/209468017-7e162ee3-dde1-4623-a2c2-8e7d14b1e54e.png)

Found while working on #23 

This PR also makes 2 minor changes:
- changed the automatic config warning to be less damning, as discussed with @BlackSamorez 
- changed minimal pytorch version in config to 1.11 (because kaggle)