### PR TITLE
torch.testing.assert_close

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -27,9 +27,9 @@ def test_embeds_and_linear(devices):
         model_tp = TensorParallel(model_tp, device_ids=devices)
         out_ours = model_tp(inputs)
         out_ours.norm().backward()
-        assert torch.allclose(ref_out, out_ours, atol=1e-6)
+        torch.testing.assert_close(ref_out, out_ours, atol=1e-6, rtol=1e-05)
         our_grad = torch.cat([next(shard[0].parameters()).grad for shard in model_tp.module_shards], dim=1)
-        assert torch.allclose(model[0].weight.grad, our_grad, atol=1e-6)
+        torch.testing.assert_close(model[0].weight.grad, our_grad, atol=1e-6, rtol=1e-05)
 
 
 @pytest.mark.parametrize("devices", [None, ("cpu",), ("cpu",) * 2, ("cpu",) * 3, ("cpu",) * 4])
@@ -62,5 +62,5 @@ def test_convs(devices, extra_options):
         model_tp = TensorParallel(model_tp, device_ids=devices)
         out_ours = model_tp(inputs2)
         out_ours.norm().backward()
-        assert torch.allclose(ref_out, out_ours, atol=1e-6), abs(ref_out - out_ours).max()
-        assert torch.allclose(inputs1.grad, inputs2.grad, atol=1e-5), abs(inputs1.grad - inputs2.grad).max()
+        torch.testing.assert_close(ref_out, out_ours, atol=1e-6, rtol=1e-05)
+        torch.testing.assert_close(inputs1.grad, inputs2.grad, atol=1e-5, rtol=1e-05)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -61,10 +61,10 @@ def test_tp_bloom_block(devices, custom_config):
     )
     y_ours.backward(grad_proj)
 
-    assert torch.allclose(y_ours, y_ref, atol=1e-6)
-    assert torch.allclose(test_inputs1.grad, test_inputs2.grad, atol=1e-6)
-    assert torch.allclose(cache_ref[0], cache_ours[0], atol=1e-6)
-    assert torch.allclose(cache_ref[1], cache_ours[1], atol=1e-6)
+    torch.testing.assert_close(y_ours, y_ref, atol=1e-6, rtol=1e-05)
+    torch.testing.assert_close(test_inputs1.grad, test_inputs2.grad, atol=1e-6, rtol=1e-05)
+    torch.testing.assert_close(cache_ref[0], cache_ours[0], atol=1e-6, rtol=1e-05)
+    torch.testing.assert_close(cache_ref[1], cache_ours[1], atol=1e-6, rtol=1e-05)
 
 
 def _prepare_attn_mask(attention_mask: torch.Tensor, input_shape: Tuple[int, int], past_key_values_length: int):

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -31,10 +31,10 @@ def test_bloom_inference(use_config, devices, model_name="bigscience/bloom-560m"
     out2 = model_tp(inp2, use_cache=True, past_key_values=out1.past_key_values)
     out3 = model_tp(inp3, use_cache=True, past_key_values=out2.past_key_values)
 
-    assert torch.allclose(out1_ref.hidden_states[-1], out1.hidden_states[-1], atol=3e-3)
-    assert torch.allclose(out1_ref.logits, out1.logits, atol=3e-3)
-    assert torch.allclose(out2_ref.logits, out2.logits, atol=3e-3)
-    assert torch.allclose(out3_ref.logits, out3.logits, atol=3e-3)
+    torch.testing.assert_close(out1_ref.hidden_states[-1], out1.hidden_states[-1], atol=3e-3, rtol=1e-05)
+    torch.testing.assert_close(out1_ref.logits, out1.logits, atol=3e-3, rtol=1e-05)
+    torch.testing.assert_close(out2_ref.logits, out2.logits, atol=3e-3, rtol=1e-05)
+    torch.testing.assert_close(out3_ref.logits, out3.logits, atol=3e-3, rtol=1e-05)
 
 
 @pytest.mark.parametrize("num_beams", [1, 3])


### PR DESCRIPTION
[torch.testing.assert_close](https://pytorch.org/docs/stable/testing.html) is simply the better way to do this. The fail prints are very informative