### PR TITLE
Check devices in forward; optionally delay moving modules to cuda

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = tensor_parallel
-version = 1.0.22
+version = 1.0.23
 author = Andrei Panferov and Yaroslav Lisnyak
 author_email = yalisnyak@nes.com
 description = Automatically shard your large model between multiple GPUs, works without torch.distributed

--- a/src/tensor_parallel/slicer_wrapper.py
+++ b/src/tensor_parallel/slicer_wrapper.py
@@ -137,7 +137,7 @@ class Config:
         source_tensors = dict(chain(module.named_parameters(), module.named_buffers()))
         _maybe_parameter = lambda x, buf: nn.Parameter(buf, x.requires_grad) if isinstance(x, nn.Parameter) else x
         substitutes = {
-            id(x): _maybe_parameter(x, torch.empty([], dtype=x.dtype, device=x.device, requires_grad=x.requires_grad))
+            id(x): _maybe_parameter(x, torch.empty(0, dtype=x.dtype, device=x.device, requires_grad=x.requires_grad))
             for x in source_tensors.values()
         }
         shard = deepcopy(module, memo=substitutes).to(device)

--- a/src/tensor_parallel/tensor_parallel.py
+++ b/src/tensor_parallel/tensor_parallel.py
@@ -86,7 +86,7 @@ class TensorParallel(nn.Module):
 
         # more self-diagnostics: make sure that the model was not cast .to one device
         self._sanity_check_params = nn.ParameterList(
-            [nn.Parameter(torch.empty(0, device=device)) for device in self.devices]
+            [nn.Parameter(torch.empty(0, device=device), requires_grad=False) for device in self.devices]
         )
 
     def forward(self, *args, **kwargs):

--- a/src/tensor_parallel/tensor_parallel.py
+++ b/src/tensor_parallel/tensor_parallel.py
@@ -82,16 +82,18 @@ class TensorParallel(nn.Module):
         )
 
         # more self-diagnostics: make sure that the model was not cast .to one device
-        self._sanity_check_params = nn.ParameterList([
-            nn.Parameter(torch.empty(0, device=device)) for device in self.devices
-        ])
+        self._sanity_check_params = nn.ParameterList(
+            [nn.Parameter(torch.empty(0, device=device)) for device in self.devices]
+        )
 
     def forward(self, *args, **kwargs):
         if len(self.module_shards) <= 1:
             return [self.module_shards[0](*args, **kwargs)][self.output_device_index]
         if not all(p.device == d for p, d in zip(self._sanity_check_params, self.devices)):
-            raise ValueError("Model parameters were moved to incorrect devices, did call on model.cuda() or "
-                             "model.to(device)? If so, please avoid doing that")
+            raise ValueError(
+                "Model parameters were moved to incorrect devices, did call on model.cuda() or "
+                "model.to(device)? If so, please avoid doing that"
+            )
         args_and_kwargs = (args, kwargs)
         flat_tensors = [obj for obj in nested_flatten(args_and_kwargs) if isinstance(obj, torch.Tensor)]
         flat_tensors_replicated = broadcast_coalesced(flat_tensors, self.devices, all_cuda=self.all_cuda)

--- a/src/tensor_parallel/tensor_parallel.py
+++ b/src/tensor_parallel/tensor_parallel.py
@@ -54,7 +54,7 @@ class TensorParallel(nn.Module):
 
         if len(device_ids) <= 1:
             self.module_shards.append(module)
-            if len(device_ids) == 1:
+            if len(device_ids) == 1 and not delay_init:
                 self.module_shards[0].to(device_ids[0])
             return
 


### PR DESCRIPTION
Problem: if user calls model.cuda() after model was converted to tensor_parallel, the model shards will all be placed to device 0, and the tensor_parallel module will not work.

This PR does the following:
- creates "indicator" parameters to verify that the model was not moved
   - these are empty parameters assigned to all kinds of devices; If user calls model.cuda(), they will be moved to one device
   - in forward, tp would now check that these modules are still assigned to their original devices, and if not, raises an error
- this PR also makes a slightly better job at initializing model shards
   - previously, model would be initialzied with empty parameters with torch.empty([], ...)
   - torch.empty([], ...) are __scalar__ tensors with numel() == 1
   - instead, we will now initialize tensors with empty(0, ...), which are zero-element tensors
   - this does not have any significant effect on anything, but it is the better way™ to create such tensors (outside of device='meta' which does not work in our case)
- this PR also adds an option to delay model init such that model_shards are moved to devices after TensorParallel init
   - why: when combining with bitsandbytes, you need to
       1. create TensorParallel before wrapping model with bitsandbytes
       2. wrap model with bitsandbytes while the model is still on CPU
    - recommended init order for bitsandbytes
       - create model
       - wrap with TensorParallel with delayed init = True
       - wrap model with bitsandbytes
       - move model to cuda