### PR TITLE
_reorder_cache fix for generation utils

### DIFF
--- a/src/tensor_parallel/pretrained_model.py
+++ b/src/tensor_parallel/pretrained_model.py
@@ -108,7 +108,7 @@ class TensorParallelPreTrainedModel(PreTrainedModel):
 
     def _reorder_cache(self, past, beam_idx):
         for i, shard in enumerate(self.wrapped_model.module_shards):
-            shard._reorder_cache(nested_map(lambda x: x[i] if isinstance(x, PerDeviceTensors) else x, past), beam_idx)
+            shard._reorder_cache(nested_map(lambda x: x[i] if isinstance(x, PerDeviceTensors) else x, past), beam_idx.to(self.wrapped_model.devices[i]))
 
     def get_encoder(self):
         assert len(self.wrapped_model.module_shards), "Can't get encoder since no module shards present"

--- a/src/tensor_parallel/pretrained_model.py
+++ b/src/tensor_parallel/pretrained_model.py
@@ -108,7 +108,10 @@ class TensorParallelPreTrainedModel(PreTrainedModel):
 
     def _reorder_cache(self, past, beam_idx):
         for i, shard in enumerate(self.wrapped_model.module_shards):
-            shard._reorder_cache(nested_map(lambda x: x[i] if isinstance(x, PerDeviceTensors) else x, past), beam_idx.to(self.wrapped_model.devices[i]))
+            shard._reorder_cache(
+                nested_map(lambda x: x[i] if isinstance(x, PerDeviceTensors) else x, past),
+                beam_idx.to(self.wrapped_model.devices[i]),
+            )
 
     def get_encoder(self):
         assert len(self.wrapped_model.module_shards), "Can't get encoder since no module shards present"

--- a/src/tensor_parallel/sharding.py
+++ b/src/tensor_parallel/sharding.py
@@ -74,6 +74,10 @@ class Sharded(nn.ModuleList):
         self._last_versions = None  # to be updated during first forward
 
     @property
+    def devices(self):
+        return self.module.devices
+
+    @property
     def preserve_shards_when_saving(self):
         return self.module.preserve_shards_when_saving
 


### PR DESCRIPTION
It's unclear on what device an auxiliary tensor `beam_idx` are located during beam-search generation and it has caused some issues.
This PR explicitly puts `beam_idx` on correct device for each model shard.