### PR TITLE
Unpersistent buffers meta loading fix

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = tensor_parallel
-version = 1.1.1
+version = 1.1.2
 author = Andrei Panferov and Yaroslav Lisnyak
 author_email = yalisnyak@nes.com
 description = Automatically shard your large model between multiple GPUs, works without torch.distributed

--- a/src/tensor_parallel/tensor_parallel.py
+++ b/src/tensor_parallel/tensor_parallel.py
@@ -67,9 +67,7 @@ class TensorParallel(nn.Module):
         # ^-- creates a copy of comfig with collective op instances, such as AllReduce and AllGather
 
         for rank, device in enumerate(self.devices):
-            if any(p.device.type == "meta" for p in module.parameters()):
-                device = torch.device("meta")
-            elif delay_init:
+            if delay_init:
                 device = torch.device("cpu")
             self.module_shards.append(
                 config.make_shard(module, device, config_with_ops, rank=rank, world_size=world_size)


### PR DESCRIPTION
Right now if a model contains any meta tensors it will fully be placed on meta device.

Normally all the data will be loaded when dispatching the model but unpersistent buffer will not be loaded and will remain on meta.

This PR fixes this behavior.