### PR TITLE
Converting state dicts without model creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,25 +81,7 @@ Such code saves a model as if it was never split. It works by gathering model pa
 
 Normally, to normally create and dispatch a `tensor_parallel` model, one needs the whole model in memory. This can be troublesome, but there is another way.
 
-It's possible to create a `tensor_parallel` on a machine with enough RAM, save it preserving distributed state, and then reuse the save files to dispatch model shards straight to GPUs on any other machine.
-
-The code to save distributed state should look like this:
-
-```python
-import transformers
-import tensor_parallel as tp
-
-RAM_LIMIT = "6GB" # we want to deploy the model on machines with as little as 6GB of RAM
-
-model = tp.TensorParallelPreTrainedModel(
-    transformers.AutoModelForCausalLM.from_pretrained("facebook/opt-13b"), 
-    device_ids=["cpu", "cpu"] # split the model but it load into RAM
-)
-
-model.save_pretrained("opt-13b-tensor-parallel", max_shard_size=RAM_USAGE_LIMIT) # save the model's distributed state
-```
-
-It normally produces many files containing model weights as well as model index. Those files then can be put on a machine for training/inference and loaded as follows:
+It's possible to convert a `state_dict` of a basic model into the corresponding `tensor_parallel` `state_dict` using a helper function `convert_state_dict`. The state dict can then be dispatched and loaded into the model:
 
 ```python
 import transformers
@@ -107,25 +89,28 @@ import tensor_parallel as tp
 
 from accelerate import init_empty_weights, load_checkpoint_in_model
 
-# Initialize a weightless model
+# Initialize a weightless tensor_parallel model from MyModel
 with init_empty_weights():
-    model = tp.TensorParallelPreTrainedModel(
-        transformers.AutoModelForCausalLM.from_config(
-            AutoConfig.from_pretrained("facebook/opt-13b")
-        ),
+    model = tp.TensorParallel(
+        MyModel(),
         device_ids=[0, 1] # and prepare it to be put on GPUs 0 and 1
     )
 
-device_map = tp.infer_sharded_device_map(model_tp) # assign parameter to devices
+# Load partial state_dict for MyModel
+state_dict = torch.load("my_model_part_1_of_5.bin")
 
-# Incrementally load the weights using your favorite loader
-load_checkpoint_in_model(
-    model,
-    checkpoint="opt-13b-tensor-parallel/pytorch_model.bin.index.json",
-    device_map=device_map,
+# Convert it into a tensor_parallel state_dict
+tensor_parallel_state_dict = tp.tensor_parallel(
+    state_dict,
+    tensor_parallel_config=model.tensor_parallel_config,
+    world_size=len(model.devices),
 )
+
+# Dispatch the partial state_dict
+model.load_state_dict(tensor_parallel_state_dict)
 ```
-Max RAM consumption of such loading is *max_shard_size*, which in this example was set to 6 GB.
+
+With this no more than one part of the model needs to be loaded into memory at once. 
   
 ## FAQ
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = tensor_parallel
-version = 1.1.3
+version = 1.1.4
 author = Andrei Panferov and Yaroslav Lisnyak
 author_email = yalisnyak@nes.com
 description = Automatically shard your large model between multiple GPUs, works without torch.distributed

--- a/src/tensor_parallel/__init__.py
+++ b/src/tensor_parallel/__init__.py
@@ -3,7 +3,7 @@ A prototype TensorParallel wrapper that works without torch.distributed.
 Splits linear, conv and some other layers between GPUs
 """
 
-from tensor_parallel.dispatch import infer_sharded_device_map, save_tensor_parallel
+from tensor_parallel.dispatch import convert_state_dict, infer_sharded_device_map, save_tensor_parallel
 from tensor_parallel.factory import tensor_parallel
 from tensor_parallel.pretrained_model import TensorParallelPreTrainedModel
 from tensor_parallel.sharding import Sharded

--- a/src/tensor_parallel/dispatch.py
+++ b/src/tensor_parallel/dispatch.py
@@ -50,7 +50,15 @@ def infer_sharded_data_device_id(name: str):
     return int(name[shard_id_start:shard_id_end]) if shard_id_end > 0 else int(name[shard_id_start:])
 
 
-def infer_sharded_device_map(tp_model):
+def infer_sharded_device_map(tp_model: Union[TensorParallel, TensorParallelPreTrainedModel]) -> dict:
+    """Creates a mapping describing which device each tensor parallel model parameter should be put on.
+
+    Args:
+        tp_model (Union[TensorParallel, TensorParallelPreTrainedModel]): tensor parallel model
+
+    Returns:
+        dict: parameter device mapping
+    """
     device_map = {}
     for name, _ in tp_model.named_parameters():
         device_map[name] = tp_model.devices[infer_sharded_data_device_id(name)]
@@ -59,10 +67,25 @@ def infer_sharded_device_map(tp_model):
     return device_map
 
 
-def convert_state_dict(input_state_dict, config: Config, world_size: int, for_pretrained: bool = False) -> dict:
+def convert_state_dict(
+    input_state_dict, tensor_parallel_config: Config, world_size: int, for_pretrained: bool = False
+) -> dict:
+    """Creates a state_dict to be loaded into a tensor parallel model from a state_dict of a base model.
+
+    Args:
+        input_state_dict (_type_): state_dict to be converted
+        tensor_parallel_config (Config): tensor parallel config for the base model
+        world_size (int): number of devices of the tensor parallel model
+        for_pretrained (bool, optional): Whether to create a state dict to be loaded into TensorParallelModel of PreTrainedTensorParallelModel. Defaults to False.
+
+    Returns:
+        dict: _description_
+    """
     output_state_dict = {}
     for i in range(world_size):
-        output_state_dict.update(convert_state_dict_single_shard(input_state_dict, config, world_size, i))
+        output_state_dict.update(
+            convert_state_dict_single_shard(input_state_dict, tensor_parallel_config, world_size, i)
+        )
         output_state_dict[f"_sanity_check_params.{i}"] = torch.empty(0, device="cpu")
     if for_pretrained:
         name_replacements = {name: "wrapped_model." + name for name in output_state_dict.keys()}
@@ -71,9 +94,9 @@ def convert_state_dict(input_state_dict, config: Config, world_size: int, for_pr
     return output_state_dict
 
 
-def convert_data(input_state_dict, output_state_dict, config: Config, world_size: int, rank: int):
+def convert_data(input_state_dict, output_state_dict, tensor_parallel_config: Config, world_size: int, rank: int):
     for name, state in input_state_dict.items():
-        for pattern, action in config.state_rules.items():
+        for pattern, action in tensor_parallel_config.state_rules.items():
             if pattern.search(name) is not None:
                 output_state_dict[name] = apply_action(state, action, rank=rank, world_size=world_size)
                 break
@@ -81,8 +104,11 @@ def convert_data(input_state_dict, output_state_dict, config: Config, world_size
             output_state_dict[name] = input_state_dict[name]  # copy source parameter as is
 
 
-def convert_names(state_dict, config: Config):
-    patterns = tuple(regex.pattern for regex in chain(config.input_rules.keys(), config.output_rules.keys()))
+def convert_names(state_dict, tensor_parallel_config: Config):
+    patterns = tuple(
+        regex.pattern
+        for regex in chain(tensor_parallel_config.input_rules.keys(), tensor_parallel_config.output_rules.keys())
+    )
     patterns = set(pattern[:-1] + "\." if pattern.endswith("$") else pattern for pattern in patterns)
     patterns = [re.compile(pattern) for pattern in patterns]
 
@@ -105,9 +131,9 @@ def prefix_names_with_shard_id(state_dict, rank: int):
         state_dict[new_name] = state_dict.pop(old_name)
 
 
-def convert_state_dict_single_shard(input_state_dict, config: Config, world_size: int, rank: int):
+def convert_state_dict_single_shard(input_state_dict, tensor_parallel_config: Config, world_size: int, rank: int):
     output_state_dict = {}
-    convert_data(input_state_dict, output_state_dict, config, world_size, rank)
-    convert_names(output_state_dict, config)
+    convert_data(input_state_dict, output_state_dict, tensor_parallel_config, world_size, rank)
+    convert_names(output_state_dict, tensor_parallel_config)
     prefix_names_with_shard_id(output_state_dict, rank)
     return output_state_dict

--- a/src/tensor_parallel/dispatch.py
+++ b/src/tensor_parallel/dispatch.py
@@ -83,7 +83,7 @@ def convert_data(input_state_dict, output_state_dict, config: Config, world_size
 
 def convert_names(state_dict, config: Config):
     patterns = tuple(regex.pattern for regex in chain(config.input_rules.keys(), config.output_rules.keys()))
-    patterns = set(pattern[:-1] if pattern.endswith("$") else pattern for pattern in patterns)
+    patterns = set(pattern[:-1] + "\." if pattern.endswith("$") else pattern for pattern in patterns)
     patterns = [re.compile(pattern) for pattern in patterns]
 
     name_replacements = {name: name for name in state_dict.keys()}
@@ -92,7 +92,7 @@ def convert_names(state_dict, config: Config):
             match = pattern.search(old_name)
             if match is not None:
                 end_pos = match.span()[1]
-                new_name = old_name[:end_pos] + ".tp_wrapped_module" + old_name[end_pos:]
+                new_name = old_name[:end_pos] + "tp_wrapped_module." + old_name[end_pos:]
                 name_replacements[initial_name] = new_name
 
     for initial_name, final_name in name_replacements.items():

--- a/src/tensor_parallel/sharding.py
+++ b/src/tensor_parallel/sharding.py
@@ -78,6 +78,10 @@ class Sharded(nn.ModuleList):
         return self.module.devices
 
     @property
+    def tensor_parallel_config(self):
+        return self.module.tensor_parallel_config
+
+    @property
     def preserve_shards_when_saving(self):
         return self.module.preserve_shards_when_saving
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -55,7 +55,7 @@ def test_tp_bloom_block(devices, custom_config):
     )
     y_ref.backward(grad_proj)
 
-    block_tp = TensorParallel(block, devices, config=tp_config)
+    block_tp = TensorParallel(block, devices, tensor_parallel_config=tp_config)
     y_ours, cache_ours = block_tp(
         test_inputs2, use_cache=True, layer_past=layer_past, alibi=alibi, attention_mask=attention_mask
     )

--- a/tests/test_saving.py
+++ b/tests/test_saving.py
@@ -8,10 +8,12 @@ from tensor_parallel import (
     Sharded,
     TensorParallel,
     TensorParallelPreTrainedModel,
+    convert_state_dict,
     infer_sharded_device_map,
     save_tensor_parallel,
     tensor_parallel,
 )
+from tensor_parallel.pretrained_model import find_predefined_tensor_parallel_config
 
 PATH_TO_SAVE = "/tmp/"
 
@@ -21,7 +23,9 @@ PATH_TO_SAVE = "/tmp/"
 def test_no_parallelism_zero_3(devices, model_name):
     model = AutoModel.from_pretrained(model_name).to(devices[0])
     model_state_dict = model.state_dict()
-    model_tp = Sharded(TensorParallel(model, devices, config=Config({}, {}, {}, {})))  # zero-3 sharding only
+    model_tp = Sharded(
+        TensorParallel(model, devices, tensor_parallel_config=Config({}, {}, {}, {}))
+    )  # zero-3 sharding only
     with save_tensor_parallel(model_tp):
         model_tp_state_dict = model_tp.state_dict()
 
@@ -125,3 +129,31 @@ def test_save_shards_load_shards(devices, model_name, pretrained):
         device_map=infer_sharded_device_map(model_tp),
     )
     assert not "meta" in [p.device.type for p in model_tp.parameters()]
+
+
+@pytest.mark.parametrize("devices", [("cpu",) * 2, ("cpu",) * 3])
+@pytest.mark.parametrize("model_name", ["bert-base-uncased"])
+def test_convert_state_dict(devices, model_name):
+    model = AutoModel.from_pretrained(model_name).to(devices[0])
+    torch.save(model.state_dict(), PATH_TO_SAVE + "test_convert_state_dict.bin")
+
+    model_tp = TensorParallelPreTrainedModel(model, devices)
+    del model
+
+    model_tp_state_dict = model_tp.state_dict()
+    converted_state_dict = convert_state_dict(
+        torch.load(PATH_TO_SAVE + "test_convert_state_dict.bin"),
+        model_tp.tensor_parallel_config,
+        world_size=len(devices),
+        for_pretrained=True,
+    )
+
+    assert sorted(list(model_tp_state_dict.keys())) == sorted(list(converted_state_dict.keys()))
+
+    for name in model_tp_state_dict.keys():
+        data_tp = model_tp_state_dict[name]
+        data_converted = converted_state_dict[name]
+
+        assert data_tp.shape == data_converted.shape
+
+        torch.testing.assert_close(data_tp, data_converted)

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -66,7 +66,7 @@ def test_forward_gpt2_like(use_config, devices, model_name):
     tp_config = None
     if use_config:
         tp_config = find_predefined_tensor_parallel_config(model.config, devices)
-    model_tp = TensorParallel(model, devices, config=tp_config)
+    model_tp = TensorParallel(model, devices, tensor_parallel_config=tp_config)
     del model
 
     out1 = model_tp(inp1, use_cache=True, output_hidden_states=True)
@@ -97,7 +97,7 @@ def test_forward_t5_like(use_config, devices, model_name):
     tp_config = None
     if use_config:
         tp_config = find_predefined_tensor_parallel_config(model.config, devices)
-    model_tp = TensorParallel(model, devices, config=tp_config)
+    model_tp = TensorParallel(model, devices, tensor_parallel_config=tp_config)
     del model
 
     out1 = model_tp(enc, decoder_input_ids=dec1, use_cache=True, output_hidden_states=True)
@@ -129,7 +129,7 @@ def test_forward_bert_like(use_config, devices, model_name):
     tp_config = None
     if use_config:
         tp_config = find_predefined_tensor_parallel_config(model.config, devices)
-    model_tp = TensorParallel(model, devices, config=tp_config)
+    model_tp = TensorParallel(model, devices, tensor_parallel_config=tp_config)
     del model
 
     out1 = model_tp(inp1, output_hidden_states=True)


### PR DESCRIPTION
_Before this PR_ it was necessary for a model to fit into RAM to be converted to `tensor_parallel`.
```python
model = tp.TensorParallelPreTrainedModel(
    transformers.AutoModelForCausalLM.from_pretrained("facebook/opt-13b"), # <- tons of RAM
    device_ids=[0, 1, 3, 4]
)
```
Or you could save a converted model to then efficiently dispatch it. But then again it needed to be converted on a machine with tons of RAM.

This PR adds the option to **independently convert parts of a model's state dict** using `convert_state_dict` helper function. Those converted parts can then be efficiently dispatched one by one.