### PR TITLE
tp.convert_state_dict readme example fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ with init_empty_weights():
 state_dict = torch.load("my_model_part_1_of_5.bin")
 
 # Convert it into a tensor_parallel state_dict
-tensor_parallel_state_dict = tp.tensor_parallel(
+tensor_parallel_state_dict = tp.convert_state_dict(
     state_dict,
     tensor_parallel_config=model.tensor_parallel_config,
     world_size=len(model.devices),


### PR DESCRIPTION
As mentioned in #77, now readme says:
```
import transformers
import tensor_parallel as tp

from accelerate import init_empty_weights, load_checkpoint_in_model

# Initialize a weightless tensor_parallel model from MyModel
with init_empty_weights():
    model = tp.TensorParallel(
        MyModel(),
        device_ids=[0, 1] # and prepare it to be put on GPUs 0 and 1
    )

# Load partial state_dict for MyModel
state_dict = torch.load("my_model_part_1_of_5.bin")

# Convert it into a tensor_parallel state_dict
tensor_parallel_state_dict = tp.tensor_parallel(
    state_dict,
    tensor_parallel_config=model.tensor_parallel_config,
    world_size=len(model.devices),
)

# Dispatch the partial state_dict
model.load_state_dict(tensor_parallel_state_dict)
```
, which is wrong. It should say
```python
import accelerate
import transformers

import tensor_parallel as tp

# Initialize a weightless tensor_parallel model from MyModel
with accelerate.init_empty_weights():
    model = tp.TensorParallel(
        MyModel(),
        device_ids=[0, 1] # and prepare it to be put on GPUs 0 and 1
    )

# Load partial state_dict for MyModel
state_dict = torch.load("my_model_part_1_of_5.bin")

# Convert it into a tensor_parallel state_dict
tensor_parallel_state_dict = tp.convert_state_dict(
    state_dict,
    tensor_parallel_config=model.tensor_parallel_config,
    world_size=len(model.devices),
)

# Dispatch the partial state_dict (load_state_dict doesn't work with meta so here I use accelerate)
device_map = tp.infer_sharded_device_map(model)
for param_name, param in state_dict.items():
  module_name = param_name
  while len(module_name) > 0 and module_name not in device_map:
      module_name = ".".join(module_name.split(".")[:-1])
  param_device = device_map[module_name]
  accelerate.utils.set_module_tensor_to_device(model, param_name, param_device, value=param)
```