### PR TITLE
Removing PEFT from dependencies. Replacing with runtime checks

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = tensor_parallel
-version = 1.2.4
+version = 1.2.5
 author = Andrei Panferov and Yaroslav Lisnyak
 author_email = yalisnyak@nes.com
 description = Automatically shard your large model between multiple GPUs, works without torch.distributed

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,6 @@ python_requires = >=3.7
 install_requires =
     torch>=1.11
     transformers>=4.20.1
-    peft>=0.3.0
 [options.extras_require]
 dev =
     pytest==6.2.5
@@ -44,6 +43,7 @@ dev =
     black==22.3.0
     isort==5.10.1
     psutil
+    peft>=0.3.0
 
 [options.packages.find]
 where = src

--- a/src/tensor_parallel/config.py
+++ b/src/tensor_parallel/config.py
@@ -6,7 +6,6 @@ from functools import partial
 from typing import Any, Callable, Dict, Sequence, Union
 
 import torch
-from peft.tuners.lora import LoraLayer
 from torch import nn
 
 import tensor_parallel.cross_device_ops as cross_device_ops
@@ -19,6 +18,7 @@ from tensor_parallel.communications import (
     NCCLAllReduce,
 )
 from tensor_parallel.state_actions import LegacyStateAction, Split, StateAction
+from tensor_parallel.utils import check_lora
 
 logger = logging.getLogger(__file__)
 
@@ -129,7 +129,7 @@ def add_lora_rules(model: nn.Module, config: Config) -> Config:
     lora_input_rules = {}
     lora_output_rules = {}
     for name, module in model.named_modules():
-        if isinstance(module, LoraLayer):
+        if check_lora(module=module):
             for pattern, action in config.state_rules.items():
                 if pattern.search(name + ".weight") is not None:
                     if isinstance(action, Split):

--- a/src/tensor_parallel/imports.py
+++ b/src/tensor_parallel/imports.py
@@ -1,0 +1,7 @@
+from importlib.metadata import version
+
+
+def verify_peft_version():
+    peft_version = version("peft")
+    if peft_version < "0.3.0":
+        raise ImportError("tensor_parallel only works with peft>=0.3.0")

--- a/src/tensor_parallel/imports.py
+++ b/src/tensor_parallel/imports.py
@@ -1,7 +1,7 @@
-from importlib.metadata import version
+import pkg_resources
 
 
 def verify_peft_version():
-    peft_version = version("peft")
+    peft_version = pkg_resources.get_distribution("peft").version
     if peft_version < "0.3.0":
         raise ImportError("tensor_parallel only works with peft>=0.3.0")

--- a/src/tensor_parallel/utils.py
+++ b/src/tensor_parallel/utils.py
@@ -3,11 +3,14 @@ Utility functions that help you process nested dicts, tuples, lists and namedtup
 Based on: https://stackoverflow.com/questions/49739102/python-nested-dictionary-comparison
 """
 
+from inspect import getmodule
 from itertools import chain
 from typing import Mapping, Optional, Sequence
 
 from torch import nn
 from transformers.modeling_outputs import BaseModelOutputWithPastAndCrossAttentions
+
+from tensor_parallel.imports import verify_peft_version
 
 
 def nested_compare(t, u):
@@ -123,3 +126,16 @@ def find_tied_weight_aliases(
             find_tied_weight_aliases(module=submodule, destination=destination, prefix=prefix + name + ".")
 
     return destination
+
+
+def check_lora(module: nn.Module) -> bool:
+    definition_module = getmodule(module)
+    if (
+        definition_module is not None
+        and definition_module.__name__ == "peft.tuners.lora"
+        and type(module).__name__ == "Linear"
+    ):
+        verify_peft_version()
+        return True
+    else:
+        return False

--- a/src/tensor_parallel/utils.py
+++ b/src/tensor_parallel/utils.py
@@ -129,13 +129,17 @@ def find_tied_weight_aliases(
 
 
 def check_lora(module: nn.Module) -> bool:
+    """Checks if module is lora Linear from a correct version of PEFT
+
+    Args:
+        module (nn.Module): module to check
+
+    Returns:
+        bool: result
+    """
     definition_module = getmodule(module)
-    if (
-        definition_module is not None
-        and definition_module.__name__ == "peft.tuners.lora"
-        and type(module).__name__ == "Linear"
-    ):
+    if definition_module is not None and definition_module.__name__ == "peft.tuners.lora":
         verify_peft_version()
-        return True
+        return type(module).__name__ == "Linear"
     else:
         return False


### PR DESCRIPTION
[PEFT](https://github.com/huggingface/peft) is pretty experimental and requiring everyone install it seems unnecessary since it's only used for a very specific use-case.
This PR hides PEFT checks and imports behind runtime inspections.