### PR TITLE
explicitly choose whether or not to use torch.distribute

### DIFF
--- a/src/tensor_parallel/factory.py
+++ b/src/tensor_parallel/factory.py
@@ -61,14 +61,22 @@ def tensor_parallel(
     else:
         if isinstance(module, PreTrainedModel):
             module = TensorParallelPreTrainedModel(
-                module, device_ids=device_ids, tensor_parallel_config=tensor_parallel_config, distributed=distributed, **kwargs
+                module,
+                device_ids=device_ids,
+                tensor_parallel_config=tensor_parallel_config,
+                distributed=distributed,
+                **kwargs,
             )
             module.wrapped_model = _maybe_sharded(
                 module.wrapped_model, sharded, num_trainable_parameters, sharded_param_names=sharded_param_names
             )
         else:
             module = TensorParallel(
-                module, device_ids=device_ids, tensor_parallel_config=tensor_parallel_config, distributed=distributed, **kwargs
+                module,
+                device_ids=device_ids,
+                tensor_parallel_config=tensor_parallel_config,
+                distributed=distributed,
+                **kwargs,
             )
             module = _maybe_sharded(module, sharded, num_trainable_parameters, sharded_param_names=sharded_param_names)
 

--- a/src/tensor_parallel/factory.py
+++ b/src/tensor_parallel/factory.py
@@ -61,14 +61,14 @@ def tensor_parallel(
     else:
         if isinstance(module, PreTrainedModel):
             module = TensorParallelPreTrainedModel(
-                module, device_ids=device_ids, tensor_parallel_config=tensor_parallel_config, **kwargs
+                module, device_ids=device_ids, tensor_parallel_config=tensor_parallel_config, distributed=distributed, **kwargs
             )
             module.wrapped_model = _maybe_sharded(
                 module.wrapped_model, sharded, num_trainable_parameters, sharded_param_names=sharded_param_names
             )
         else:
             module = TensorParallel(
-                module, device_ids=device_ids, tensor_parallel_config=tensor_parallel_config, **kwargs
+                module, device_ids=device_ids, tensor_parallel_config=tensor_parallel_config, distributed=distributed, **kwargs
             )
             module = _maybe_sharded(module, sharded, num_trainable_parameters, sharded_param_names=sharded_param_names)
 

--- a/src/tensor_parallel/pretrained_model.py
+++ b/src/tensor_parallel/pretrained_model.py
@@ -43,6 +43,7 @@ class TensorParallelPreTrainedModel(PreTrainedModel):
         output_device: Optional[torch.device] = None,
         output_device_index: Optional[int] = None,
         tensor_parallel_config: Optional[Config] = None,
+        distributed: bool = True,
     ):
         super().__init__(module.config)  # Temporary empty config. Gets replaced in from_pretrained
 
@@ -55,7 +56,7 @@ class TensorParallelPreTrainedModel(PreTrainedModel):
             tensor_parallel_config = find_predefined_tensor_parallel_config(module.config, device_ids)
 
         self.wrapped_model = TensorParallel(
-            module, device_ids, output_device, output_device_index, tensor_parallel_config
+            module, device_ids, output_device, output_device_index, tensor_parallel_config, distributed=distributed
         )
 
     @property

--- a/src/tensor_parallel/tensor_parallel.py
+++ b/src/tensor_parallel/tensor_parallel.py
@@ -30,6 +30,7 @@ class TensorParallel(nn.Module):
         output_device_index: Optional[int] = None,
         tensor_parallel_config: Optional[Config] = None,
         delay_init: bool = False,
+        distributed: bool = True,
     ):
         super().__init__()
         original_params = sum(p.numel() for p in module.parameters())
@@ -66,7 +67,7 @@ class TensorParallel(nn.Module):
         tensor_parallel_config = add_lora_rules(module, tensor_parallel_config)
         self.tensor_parallel_config = tensor_parallel_config
 
-        config_with_ops = tensor_parallel_config.create_collective_ops(self.devices)
+        config_with_ops = tensor_parallel_config.create_collective_ops(self.devices, distributed)
         # ^-- creates a copy of comfig with collective op instances, such as AllReduce and AllGather
 
         for rank, device in enumerate(self.devices):


### PR DESCRIPTION
Hi! 
This package is very interesting and reasonable for tensor parallelization.
I would like to request the function to explicitly choose whether or not to use torch.distribute.

## Issue
- We can use torch.distributed backend by `distributed` flag of `tensor_parallel.tensor_parallel`.
https://github.com/BlackSamorez/tensor_parallel/blob/0f8dcc9b358d899b6a4e1d9e65834f0258db437f/src/tensor_parallel/factory.py#L22
- But Reduce&Gather operations backend is selected internally by `torch.distributed.is_initialized()`.
https://github.com/BlackSamorez/tensor_parallel/blob/0f8dcc9b358d899b6a4e1d9e65834f0258db437f/src/tensor_parallel/config.py#L91

## Modification 
- I modified this program to explicitly choose whether or not to use torch.distribute.
  - if `distributed: bool` is `True`, Reduce&Gather operations backend is torch.distribute. (In this case, the behavior does not change from the current one.)
  -  if `distributed: bool` is `False`, Reduce&Gather operations backend does not use torch.distribute backend even though we run  torch.distribute backend (`torch.distributed.is_initialized()` is `True`). 
     - In this case, `NCCLAllReduce, NCCLAllGather` or `AllReduce, AllGather`are selected.

## Why
- For instance, we would like to use torch.distribute for `Data Parallelization` and also to use this package for `Tensor Parallelization`.
  - Currently, this program selects Reduce&Gather function internally, so `DistributedAllReduce, DistributedAllGather` are chosen.
  - Using `DistributedAllReduce, DistributedAllGather` in this case, Reduce&Gather operations are not performed correctly in the parallelized models.