### PR TITLE
LLaMA-2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,11 +39,11 @@ dev =
     pytest==6.2.5
     pytest-forked
     pytest-asyncio==0.16.0
-    accelerate==0.15.0
+    accelerate==0.20.3
     black==22.3.0
     isort==5.10.1
     psutil
-    peft>=0.3.0
+    peft==0.4.0
     einops==0.6.1
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ dev =
     black==22.3.0
     isort==5.10.1
     psutil
-    peft==0.4.0
+    peft==0.3.0
     einops==0.6.1
 [options.packages.find]
 where = src

--- a/src/tensor_parallel/slicing_configs.py
+++ b/src/tensor_parallel/slicing_configs.py
@@ -346,10 +346,13 @@ def get_llama_config(model_config: PretrainedConfig, devices: Sequence[torch.dev
     assert model_config.model_type == "llama", f"Trying to pass {model_config.model_type} as llama config"
 
     world_size = len(devices)
-    num_heads = model_config.num_attention_heads
     head_dim = model_config.hidden_size // model_config.num_attention_heads
-    num_kv = model_config.num_key_value_heads
-    q_per_kv = model_config.num_attention_heads // model_config.num_key_value_heads
+    try:
+        num_kv = model_config.num_key_value_heads
+        q_per_kv = model_config.num_attention_heads // model_config.num_key_value_heads
+    except AttributeError:
+        num_kv = model_config.num_attention_heads
+        q_per_kv = 1
 
     gather_kv_across_ranks = CollectiveOperation(
         world_size=world_size, func=lambda *kvs: gather_kv(*kvs, world_size=world_size)

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -95,13 +95,13 @@ def prepare_model(model_name, use_lora):
 @pytest.mark.parametrize(
     "model_name",
     [
-        # "bigscience/bloom-560m",
-        # "gpt2",
-        # "trl-internal-testing/tiny-random-GPTNeoXForCausalLM",
-        # "Salesforce/codegen-350M-mono",
+        "bigscience/bloom-560m",
+        "gpt2",
+        "trl-internal-testing/tiny-random-GPTNeoXForCausalLM",
+        "Salesforce/codegen-350M-mono",
         "Bingsu/llama-190m-arch",
         "BlackSamorez/llama-2-tiny-testing",
-        # "BlackSamorez/falcon-40b-tiny-testing",
+        "BlackSamorez/falcon-40b-tiny-testing",
     ],
 )
 def test_forward_gpt2_like(use_lora, use_config, devices, model_name):

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -83,6 +83,7 @@ def test_multipurpose_configs(model_classes, model_name):
         "trl-internal-testing/tiny-random-GPTNeoXForCausalLM",
         "Salesforce/codegen-350M-mono",
         "Bingsu/llama-190m-arch",
+        "BlackSamorez/llama-2-tiny-testing",
         "BlackSamorez/falcon-40b-tiny-testing",
     ],
 )

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -72,39 +72,42 @@ def test_multipurpose_configs(model_classes, model_name):
     )  # basically asserting that all of those have the same config
 
 
-@pytest.mark.parametrize("use_lora", [False, True])
-@pytest.mark.parametrize("use_config", [False, True])
-@pytest.mark.parametrize("devices", [("cpu",) * 2, ("cpu",) * 3])
-@pytest.mark.parametrize(
-    "model_name",
-    [
-        "bigscience/bloom-560m",
-        "gpt2",
-        "trl-internal-testing/tiny-random-GPTNeoXForCausalLM",
-        "Salesforce/codegen-350M-mono",
-        "Bingsu/llama-190m-arch",
-        "BlackSamorez/llama-2-tiny-testing",
-        "BlackSamorez/falcon-40b-tiny-testing",
-    ],
-)
-def test_forward_gpt2_like(use_lora, use_config, devices, model_name):
-    torch.manual_seed(0)
-
+def prepare_model(model_name, use_lora):
     if model_name == "BlackSamorez/falcon-40b-tiny-testing" and torch.__version__ < "2.0":
         pytest.skip(f"Not testing {model_name} with torch=={torch.__version__}")
+    if model_name == "BlackSamorez/llama-2-tiny-testing" and transformers.__version__ < "4.31":
+        pytest.skip(f"Not testing {model_name} with transformers=={transformers.__version__}")
 
     try:
-        model = (
-            AutoModelForCausalLM.from_pretrained(model_name, low_cpu_mem_usage=True, trust_remote_code=True)
-            .float()
-            .to(devices[0])
-        )
+        model = AutoModelForCausalLM.from_pretrained(model_name, low_cpu_mem_usage=True, trust_remote_code=True).float()
     except KeyError as err:
         pytest.skip(f"Could not create model {model_name} with error {err}")
     if use_lora:
         if model_name == "gpt2":
             pytest.skip("Not testing LoRA for gpt2")
         model = add_lora(model, model_name)
+    return model
+
+
+@pytest.mark.parametrize("use_lora", [False, True])
+@pytest.mark.parametrize("use_config", [False, True])
+@pytest.mark.parametrize("devices", [("cpu",) * 2, ("cpu",) * 3])
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        # "bigscience/bloom-560m",
+        # "gpt2",
+        # "trl-internal-testing/tiny-random-GPTNeoXForCausalLM",
+        # "Salesforce/codegen-350M-mono",
+        "Bingsu/llama-190m-arch",
+        "BlackSamorez/llama-2-tiny-testing",
+        # "BlackSamorez/falcon-40b-tiny-testing",
+    ],
+)
+def test_forward_gpt2_like(use_lora, use_config, devices, model_name):
+    torch.manual_seed(0)
+
+    model = prepare_model(model_name, use_lora)
 
     inp1 = torch.randint(1, 1000, size=(2, 3), device=devices[0])
     inp2 = torch.randint(1, 1000, size=(2, 1), device=devices[0])


### PR DESCRIPTION
The latest `transformers` require `accelerate>=0.20.3`. `accelerate==0.15.0` is used here for testing purposes. It needs to be updated.
edit: latest `transformers` also changed `LLaMA` modeling so this is now a `LLaMA-2` PR.