### PR TITLE
[WIP] ZeRO-3 refactoring (sharding)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = tensor_parallel
-version = 1.3.0
+version = 2.0.0
 author = Andrei Panferov and Yaroslav Lisnyak
 author_email = yalisnyak@nes.com
 description = Automatically shard your large model between multiple GPUs, works without torch.distributed

--- a/src/tensor_parallel/__init__.py
+++ b/src/tensor_parallel/__init__.py
@@ -5,7 +5,8 @@ Splits linear, conv and some other layers between GPUs
 
 from tensor_parallel.config import Config
 from tensor_parallel.dispatch import convert_state_dict, infer_sharded_device_map, save_tensor_parallel
-from tensor_parallel.legacy import Sharded, tensor_parallel
+from tensor_parallel.factory import tensor_parallel
+from tensor_parallel.legacy import Sharded
 from tensor_parallel.pretrained_model import TensorParallelPreTrainedModel
 from tensor_parallel.shard import make_distributed_shard
 from tensor_parallel.state_actions import StateAction

--- a/src/tensor_parallel/__init__.py
+++ b/src/tensor_parallel/__init__.py
@@ -7,6 +7,5 @@ from tensor_parallel.config import Config
 from tensor_parallel.dispatch import convert_state_dict, infer_sharded_device_map, save_tensor_parallel
 from tensor_parallel.factory import tensor_parallel
 from tensor_parallel.pretrained_model import TensorParallelPreTrainedModel
-from tensor_parallel.sharding import Sharded
 from tensor_parallel.state_actions import StateAction
 from tensor_parallel.tensor_parallel import TensorParallel

--- a/src/tensor_parallel/__init__.py
+++ b/src/tensor_parallel/__init__.py
@@ -7,5 +7,6 @@ from tensor_parallel.config import Config
 from tensor_parallel.dispatch import convert_state_dict, infer_sharded_device_map, save_tensor_parallel
 from tensor_parallel.factory import tensor_parallel
 from tensor_parallel.pretrained_model import TensorParallelPreTrainedModel
+from tensor_parallel.shard import make_distributed_shard
 from tensor_parallel.state_actions import StateAction
 from tensor_parallel.tensor_parallel import TensorParallel

--- a/src/tensor_parallel/__init__.py
+++ b/src/tensor_parallel/__init__.py
@@ -5,7 +5,7 @@ Splits linear, conv and some other layers between GPUs
 
 from tensor_parallel.config import Config
 from tensor_parallel.dispatch import convert_state_dict, infer_sharded_device_map, save_tensor_parallel
-from tensor_parallel.factory import tensor_parallel
+from tensor_parallel.legacy import Sharded, tensor_parallel
 from tensor_parallel.pretrained_model import TensorParallelPreTrainedModel
 from tensor_parallel.shard import make_distributed_shard
 from tensor_parallel.state_actions import StateAction

--- a/src/tensor_parallel/config.py
+++ b/src/tensor_parallel/config.py
@@ -168,7 +168,8 @@ def get_parameter_name_mapping(names: Iterable[str], tensor_parallel_config: Con
         regex.pattern
         for regex in chain(tensor_parallel_config.input_rules.keys(), tensor_parallel_config.output_rules.keys())
     )
-    patterns = set(pattern[:-1] + "\." if pattern.endswith("$") else pattern for pattern in patterns)
+    patterns = [pattern[:-1] if pattern.endswith("$") else pattern for pattern in patterns]
+    patterns = [pattern if pattern.endswith(".") else pattern + r"\." for pattern in patterns]
     patterns = [re.compile(pattern) for pattern in patterns]
 
     name_replacements = {name: name for name in names}

--- a/src/tensor_parallel/dispatch.py
+++ b/src/tensor_parallel/dispatch.py
@@ -6,13 +6,12 @@ import torch
 
 from tensor_parallel.config import get_parameter_name_mapping
 from tensor_parallel.pretrained_model import TensorParallelPreTrainedModel
-from tensor_parallel.sharding import Sharded
 from tensor_parallel.tensor_parallel import Config, TensorParallel
 from tensor_parallel.utils import find_tied_weight_aliases
 
 
 @contextmanager
-def save_tensor_parallel(model: Union[TensorParallel, TensorParallelPreTrainedModel, Sharded]):
+def save_tensor_parallel(model: Union[TensorParallel, TensorParallelPreTrainedModel]):
     """Enables state_dict reconstruction for tensor_parallel models.
     With it '.state_dict()' produces a state dict that can be loaded into an underlying model.
     Example:
@@ -24,13 +23,13 @@ def save_tensor_parallel(model: Union[TensorParallel, TensorParallelPreTrainedMo
     ```
 
     Args:
-        model (Union[TensorParallel, TensorParallelPreTrainedModel, Sharded]): tensor_parallel model
+        model (Union[TensorParallel, TensorParallelPreTrainedModel]): tensor_parallel model
     """
-    model.preserve_shards_when_saving = False
+    model.set_preserve_shards_when_saving(False)
     try:
         yield
     finally:
-        model.preserve_shards_when_saving = True
+        model.set_preserve_shards_when_saving(True)
 
 
 def infer_sharded_data_device_id(name: str):

--- a/src/tensor_parallel/dispatch.py
+++ b/src/tensor_parallel/dispatch.py
@@ -1,10 +1,10 @@
 import re
 from contextlib import contextmanager
-from itertools import chain
 from typing import Union
 
 import torch
 
+from tensor_parallel.config import get_parameter_name_mapping
 from tensor_parallel.pretrained_model import TensorParallelPreTrainedModel
 from tensor_parallel.sharding import Sharded
 from tensor_parallel.tensor_parallel import Config, TensorParallel
@@ -112,21 +112,7 @@ def convert_data(input_state_dict, output_state_dict, tensor_parallel_config: Co
 
 
 def convert_names(state_dict, tensor_parallel_config: Config):
-    patterns = tuple(
-        regex.pattern
-        for regex in chain(tensor_parallel_config.input_rules.keys(), tensor_parallel_config.output_rules.keys())
-    )
-    patterns = set(pattern[:-1] + "\." if pattern.endswith("$") else pattern for pattern in patterns)
-    patterns = [re.compile(pattern) for pattern in patterns]
-
-    name_replacements = {name: name for name in state_dict.keys()}
-    for pattern in patterns:
-        for initial_name, old_name in name_replacements.items():
-            match = pattern.search(old_name)
-            if match is not None:
-                end_pos = match.span()[1]
-                new_name = old_name[:end_pos] + "tp_wrapped_module." + old_name[end_pos:]
-                name_replacements[initial_name] = new_name
+    name_replacements = get_parameter_name_mapping(state_dict.keys(), tensor_parallel_config)
 
     for initial_name, final_name in name_replacements.items():
         state_dict[final_name] = state_dict.pop(initial_name)

--- a/src/tensor_parallel/factory.py
+++ b/src/tensor_parallel/factory.py
@@ -49,9 +49,13 @@ def tensor_parallel(
     """
     if "sharded" in kwargs:
         logger.warning(f"`sharded` has been renamed to `use_zero3`. Please use the latter")
+        use_zero3 = kwargs["sharded"]
+        del kwargs["sharded"]
 
     if "sharded_param_names" in kwargs:
         logger.warning(f"`sharded_param_names` has been renamed to `replicated_param_names`. Please use the latter")
+        replicated_param_names = kwargs["sharded_param_names"]
+        del kwargs["sharded_param_names"]
 
     distributed = distributed if distributed is not None else torch.distributed.is_initialized()
 

--- a/src/tensor_parallel/factory.py
+++ b/src/tensor_parallel/factory.py
@@ -44,7 +44,8 @@ def tensor_parallel(
     :param sharded: if True, any non-tensor-parallel parameters (e.g. layernorm weight) will still be sharded,
        and manually re-assembled for each forward. This is equivalent to pytorch FullyShardedDataParallel
     :param sharded_param_names: if sharded=True, this is a list of all parameter names (strings) that ZeRO-3 applies to;
-       by default, ZeRO-3 applies to all parameters that are not split with tensor parallelism and are trainable.
+       by default, ZeRO-3 applies to all parameters that are not split with tensor parallelism.
+    :note: the default sharded_param_names are formed of parameters that are equal between shards after TP is applied
     :param kwargs: additional keyword arguments passed to TensorParallel init
 
     """

--- a/src/tensor_parallel/factory.py
+++ b/src/tensor_parallel/factory.py
@@ -19,8 +19,8 @@ def tensor_parallel(
     device_ids: Optional[Sequence[Union[torch.device, str]]] = None,
     tensor_parallel_config: Optional[Config] = None,
     distributed: Optional[bool] = None,
-    use_zero3: Optional[bool] = None,
-    replicated_param_names: Optional[Collection[str]] = None,
+    sharded: Optional[bool] = None,
+    sharded_param_names: Optional[Collection[str]] = None,
     **kwargs,
 ) -> nn.Module:
     """
@@ -39,31 +39,21 @@ def tensor_parallel(
     :param tensor_parallel_config: custom tensor_parallel.Config to describe how the model is parallelized. defaults to auto config
     :param distributed: if True, use torch.distributed instead of threading. Assumes that we is running in torchrun
        defaults to True if torch.distributed.is_initialized, else False
-    :param use_zero3: if True, any non-tensor-parallel parameters (e.g. layernorm weight) will still be sharded,
+    :param sharded: if True, any non-tensor-parallel parameters (e.g. layernorm weight) will still be sharded,
        and manually re-assembled for each forward. This is equivalent to pytorch FullyShardedDataParallel
-    :param replicated_param_names: if sharded=True, this is a list of all parameter names (strings) that ZeRO-3 applies to;
+    :param sharded_param_names: if sharded=True, this is a list of all parameter names (strings) that ZeRO-3 applies to;
        by default, ZeRO-3 applies to all parameters that are not split with tensor parallelism.
-    :note: the default replicated_param_names are formed of parameters that are equal between shards after TP is applied
+    :note: the default sharded_param_names are formed of all parameters that were not processed with tensor parallelism
     :param kwargs: additional keyword arguments passed to TensorParallel init
 
     """
-    if "sharded" in kwargs:
-        logger.warning(f"`sharded` has been renamed to `use_zero3`. Please use the latter")
-        use_zero3 = kwargs["sharded"]
-        del kwargs["sharded"]
-
-    if "sharded_param_names" in kwargs:
-        logger.warning(f"`sharded_param_names` has been renamed to `replicated_param_names`. Please use the latter")
-        replicated_param_names = kwargs["sharded_param_names"]
-        del kwargs["sharded_param_names"]
-
     distributed = distributed if distributed is not None else torch.distributed.is_initialized()
 
     if distributed:
         if device_ids is None:
             device_ids = [torch.device("cuda" if torch.cuda.is_available() else "cpu")]
         assert len(device_ids) == 1, "if distributed=True, please specify a single (current) device"
-        assert not use_zero3, "distributed + sharded mode is not implemented, please keep one"
+        assert not sharded, "distributed + sharded mode is not implemented, please keep one"
 
         return make_distributed_shard(module, device=torch.device(device_ids[0]), **kwargs)
     else:
@@ -73,8 +63,8 @@ def tensor_parallel(
                 device_ids=device_ids,
                 tensor_parallel_config=tensor_parallel_config,
                 distributed=distributed,
-                use_zero3=use_zero3,
-                replicated_param_names=replicated_param_names,
+                sharded=sharded,
+                sharded_param_names=sharded_param_names,
                 **kwargs,
             )
         else:
@@ -83,7 +73,7 @@ def tensor_parallel(
                 device_ids=device_ids,
                 tensor_parallel_config=tensor_parallel_config,
                 distributed=distributed,
-                use_zero3=use_zero3,
-                replicated_param_names=replicated_param_names,
+                sharded=sharded,
+                sharded_param_names=sharded_param_names,
                 **kwargs,
             )

--- a/src/tensor_parallel/factory.py
+++ b/src/tensor_parallel/factory.py
@@ -19,11 +19,13 @@ def tensor_parallel(
     device_ids: Optional[Sequence[Union[torch.device, str]]] = None,
     tensor_parallel_config: Optional[Config] = None,
     distributed: Optional[bool] = None,
-    use_zero3: Optional[bool] = None,
-    replicated_param_names: Optional[Collection[str]] = None,
+    sharded: Optional[bool] = None,
+    sharded_param_names: Optional[Collection[str]] = None,
     **kwargs,
 ) -> nn.Module:
     """
+    !!! This function is deprecated and will be deleted in subsequent releases!!!
+
     Wrap an existing PyTorch module with tensor parallelism. Return equivalent tensor-parallel module.
 
     :example:
@@ -39,20 +41,17 @@ def tensor_parallel(
     :param tensor_parallel_config: custom tensor_parallel.Config to describe how the model is parallelized. defaults to auto config
     :param distributed: if True, use torch.distributed instead of threading. Assumes that we is running in torchrun
        defaults to True if torch.distributed.is_initialized, else False
-    :param use_zero3: if True, any non-tensor-parallel parameters (e.g. layernorm weight) will still be sharded,
+    :param sharded: if True, any non-tensor-parallel parameters (e.g. layernorm weight) will still be sharded,
        and manually re-assembled for each forward. This is equivalent to pytorch FullyShardedDataParallel
-    :param replicated_param_names: if sharded=True, this is a list of all parameter names (strings) that ZeRO-3 applies to;
+    :param sharded_param_names: if sharded=True, this is a list of all parameter names (strings) that ZeRO-3 applies to;
        by default, ZeRO-3 applies to all parameters that are not split with tensor parallelism and are trainable.
     :param kwargs: additional keyword arguments passed to TensorParallel init
 
     """
-    if "sharded_param_names" in kwargs:
-        replicated_param_names = kwargs["sharded_param_names"]
-        logger.warning(
-            f"`sharded_param_names` argument has been renamed to `replicated_param_names`. Please use the latter since the former will be deprecated."
-        )
+    logger.warning(
+        f"`tensor_parallel` is deprecated. Please use `TensorParallel`, `TensorParallelPreTrainedModel` or `make_distributed_shard`  accordingly"
+    )
 
-    num_trainable_parameters = sum(p.numel() for p in module.parameters() if p.requires_grad)
     distributed = distributed if distributed is not None else torch.distributed.is_initialized()
 
     if distributed:
@@ -69,8 +68,8 @@ def tensor_parallel(
                 device_ids=device_ids,
                 tensor_parallel_config=tensor_parallel_config,
                 distributed=distributed,
-                use_zero3=use_zero3,
-                replicated_param_names=replicated_param_names,
+                use_zero3=sharded,
+                replicated_param_names=sharded_param_names,
                 **kwargs,
             )
         else:
@@ -79,7 +78,7 @@ def tensor_parallel(
                 device_ids=device_ids,
                 tensor_parallel_config=tensor_parallel_config,
                 distributed=distributed,
-                use_zero3=use_zero3,
-                replicated_param_names=replicated_param_names,
+                use_zero3=sharded,
+                replicated_param_names=sharded_param_names,
                 **kwargs,
             )

--- a/src/tensor_parallel/legacy.py
+++ b/src/tensor_parallel/legacy.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Collection, Optional, Sequence, Union
+from typing import Collection, Optional, Sequence, Tuple, Union
 
 import torch
 import torch.distributed
@@ -83,3 +83,14 @@ def tensor_parallel(
                 replicated_param_names=sharded_param_names,
                 **kwargs,
             )
+
+
+class Sharded(nn.Module):
+    def __new__(
+        cls,
+        module: Tuple[TensorParallel, TensorParallelPreTrainedModel],
+        sharded_param_names: Optional[Collection[str]] = None,
+    ):
+        logger.warning(f"`Sharded` is deprecated. Please use `.use_zero3()` method")
+        module.use_zero3(sharded_param_names)
+        return module

--- a/src/tensor_parallel/legacy.py
+++ b/src/tensor_parallel/legacy.py
@@ -16,5 +16,5 @@ class Sharded(nn.Module):
         sharded_param_names: Optional[Collection[str]] = None,
     ):
         logger.warning(f"`Sharded` is deprecated. Please use `.use_zero3()` method")
-        module.use_zero3(sharded_param_names)
+        module.apply_zero3(sharded_param_names)
         return module

--- a/src/tensor_parallel/legacy.py
+++ b/src/tensor_parallel/legacy.py
@@ -1,0 +1,20 @@
+import logging
+from typing import Collection, Optional, Tuple
+
+from torch import nn
+
+from tensor_parallel.pretrained_model import TensorParallelPreTrainedModel
+from tensor_parallel.tensor_parallel import TensorParallel
+
+logger = logging.getLogger(__file__)
+
+
+class Sharded(nn.Module):
+    def __new__(
+        cls,
+        module: Tuple[TensorParallel, TensorParallelPreTrainedModel],
+        sharded_param_names: Optional[Collection[str]] = None,
+    ):
+        logger.warning(f"`Sharded` is deprecated. Please use `.use_zero3()` method")
+        module.use_zero3(sharded_param_names)
+        return module

--- a/src/tensor_parallel/legacy.py
+++ b/src/tensor_parallel/legacy.py
@@ -15,6 +15,6 @@ class Sharded(nn.Module):
         module: Tuple[TensorParallel, TensorParallelPreTrainedModel],
         sharded_param_names: Optional[Collection[str]] = None,
     ):
-        logger.warning(f"`Sharded` is deprecated. Please use `.use_zero3()` method")
-        module.apply_zero3(sharded_param_names)
+        logger.warning(f"`Sharded` is deprecated. Please use `.apply_sharding()` method")
+        module.apply_sharding(sharded_param_names)
         return module

--- a/src/tensor_parallel/pretrained_model.py
+++ b/src/tensor_parallel/pretrained_model.py
@@ -69,6 +69,9 @@ class TensorParallelPreTrainedModel(PreTrainedModel):
     def set_preserve_shards_when_saving(self, value: bool):
         self.wrapped_model.set_preserve_shards_when_saving(value)
 
+    def apply_zero3(self, *args, **kwargs):
+        self.wrapped_model.apply_zero3(*args, **kwargs)
+
     def forward(self, *args, **kwargs):
         return self.wrapped_model(*args, **kwargs)
 

--- a/src/tensor_parallel/pretrained_model.py
+++ b/src/tensor_parallel/pretrained_model.py
@@ -69,8 +69,8 @@ class TensorParallelPreTrainedModel(PreTrainedModel):
     def set_preserve_shards_when_saving(self, value: bool):
         self.wrapped_model.set_preserve_shards_when_saving(value)
 
-    def apply_zero3(self, *args, **kwargs):
-        self.wrapped_model.apply_zero3(*args, **kwargs)
+    def apply_sharding(self, *args, **kwargs):
+        self.wrapped_model.apply_sharding(*args, **kwargs)
 
     def forward(self, *args, **kwargs):
         return self.wrapped_model(*args, **kwargs)
@@ -131,9 +131,9 @@ class TensorParallelPreTrainedModel(PreTrainedModel):
                         shard.to(device)
                     self.wrapped_pretrained_model.wrapped_model.need_delayed_init = False
 
-                # Synchronize replicated parameters
-                if self.wrapped_pretrained_model.wrapped_model.zero3 is not None:
-                    self.wrapped_pretrained_model.wrapped_model.zero3.synchronize_weights(
+                # Synchronize sharded parameters
+                if self.wrapped_pretrained_model.wrapped_model.sharding_manager is not None:
+                    self.wrapped_pretrained_model.wrapped_model.sharding_manager.synchronize_weights(
                         self.wrapped_pretrained_model.wrapped_model.all_cuda
                     )
 

--- a/src/tensor_parallel/pretrained_model.py
+++ b/src/tensor_parallel/pretrained_model.py
@@ -11,7 +11,6 @@ from transformers import PretrainedConfig, PreTrainedModel
 
 from tensor_parallel.config import TENSOR_PARALLEL_USE_NATIVE, Config
 from tensor_parallel.per_device_tensors import PerDeviceTensors
-from tensor_parallel.sharding import Sharded
 from tensor_parallel.slicing_configs import PREDEFINED_CONFIGS
 from tensor_parallel.tensor_parallel import TensorParallel, check_device_ids, parallel_apply, parallel_apply_simple
 from tensor_parallel.utils import nested_map
@@ -43,7 +42,7 @@ class TensorParallelPreTrainedModel(PreTrainedModel):
         output_device: Optional[torch.device] = None,
         output_device_index: Optional[int] = None,
         tensor_parallel_config: Optional[Config] = None,
-        distributed: bool = True,
+        **kwargs,
     ):
         super().__init__(module.config)  # Temporary empty config. Gets replaced in from_pretrained
 
@@ -56,7 +55,7 @@ class TensorParallelPreTrainedModel(PreTrainedModel):
             tensor_parallel_config = find_predefined_tensor_parallel_config(module.config, device_ids)
 
         self.wrapped_model = TensorParallel(
-            module, device_ids, output_device, output_device_index, tensor_parallel_config, distributed=distributed
+            module, device_ids, output_device, output_device_index, tensor_parallel_config, **kwargs
         )
 
     @property
@@ -67,13 +66,8 @@ class TensorParallelPreTrainedModel(PreTrainedModel):
     def tensor_parallel_config(self):
         return self.wrapped_model.tensor_parallel_config
 
-    @property
-    def preserve_shards_when_saving(self):
-        return self.wrapped_model.preserve_shards_when_saving
-
-    @preserve_shards_when_saving.setter
-    def preserve_shards_when_saving(self, value):
-        self.wrapped_model.preserve_shards_when_saving = value
+    def set_preserve_shards_when_saving(self, value: bool):
+        self.wrapped_model.set_preserve_shards_when_saving(value)
 
     def forward(self, *args, **kwargs):
         return self.wrapped_model(*args, **kwargs)
@@ -120,70 +114,29 @@ class TensorParallelPreTrainedModel(PreTrainedModel):
             encoder_decoder_shard.get_encoder() for encoder_decoder_shard in self.wrapped_model.module_shards
         ]
 
-        encoder_wrapper_class = None
-        if isinstance(self.wrapped_model, TensorParallel):
+        class _EncoderWrapper(torch.nn.Module):
+            def __init__(self, wrapped_pretrained_model: TensorParallelPreTrainedModel) -> None:
+                super().__init__()
+                self.wrapped_pretrained_model = wrapped_pretrained_model
 
-            class _EncoderWrapper(torch.nn.Module):
-                def __init__(self, wrapped_pretrained_model: TensorParallelPreTrainedModel) -> None:
-                    super().__init__()
-                    self.wrapped_pretrained_model = wrapped_pretrained_model
-
-                def forward(self, *args, **kwargs):
-                    (
+            def forward(self, *args, **kwargs):
+                (
+                    inputs,
+                    kwargs_tup,
+                ) = self.wrapped_pretrained_model.wrapped_model.prepare_args_kwargs_for_forward(*args, **kwargs)
+                if self.wrapped_pretrained_model.wrapped_model.all_cuda and not TENSOR_PARALLEL_USE_NATIVE:
+                    return parallel_apply(
+                        encoder_shards,
                         inputs,
                         kwargs_tup,
-                    ) = self.wrapped_pretrained_model.wrapped_model.prepare_args_kwargs_for_forward(*args, **kwargs)
-                    if self.wrapped_pretrained_model.wrapped_model.all_cuda and not TENSOR_PARALLEL_USE_NATIVE:
-                        return parallel_apply(
-                            encoder_shards,
-                            inputs,
-                            kwargs_tup,
-                            self.wrapped_pretrained_model.wrapped_model.devices,
-                        )[self.wrapped_pretrained_model.wrapped_model.output_device_index]
-                    else:
-                        return parallel_apply_simple(
-                            encoder_shards,
-                            inputs,
-                            kwargs_tup,
-                            self.wrapped_pretrained_model.wrapped_model.devices,
-                        )[self.wrapped_pretrained_model.wrapped_model.output_device_index]
-
-            encoder_wrapper_class = _EncoderWrapper
-
-        elif isinstance(self.wrapped_model, Sharded):
-
-            class _EncoderWrapper(torch.nn.Module):
-                def __init__(self, wrapped_pretrained_model: TensorParallelPreTrainedModel) -> None:
-                    super().__init__()
-                    self.wrapped_pretrained_model = wrapped_pretrained_model
-
-                def forward(self, *args, **kwargs):
-                    if (
-                        len(self.wrapped_pretrained_model.wrapped_model.module.module_shards) > 1
-                        and len(self.wrapped_pretrained_model.wrapped_model.sharded_param_names) > 0
-                    ):
-                        self.wrapped_pretrained_model.wrapped_model._maybe_fill_sharded_params()
-                    (
+                        self.wrapped_pretrained_model.wrapped_model.devices,
+                    )[self.wrapped_pretrained_model.wrapped_model.output_device_index]
+                else:
+                    return parallel_apply_simple(
+                        encoder_shards,
                         inputs,
                         kwargs_tup,
-                    ) = self.wrapped_pretrained_model.wrapped_model.module.prepare_args_kwargs_for_forward(
-                        *args, **kwargs
-                    )
-                    if self.wrapped_pretrained_model.wrapped_model.module.all_cuda and not TENSOR_PARALLEL_USE_NATIVE:
-                        return parallel_apply(
-                            encoder_shards,
-                            inputs,
-                            kwargs_tup,
-                            self.wrapped_pretrained_model.wrapped_model.module.devices,
-                        )[self.wrapped_pretrained_model.wrapped_model.module.output_device_index]
-                    else:
-                        return parallel_apply_simple(
-                            encoder_shards,
-                            inputs,
-                            kwargs_tup,
-                            self.wrapped_pretrained_model.wrapped_model.module.devices,
-                        )[self.wrapped_pretrained_model.wrapped_model.module.output_device_index]
+                        self.wrapped_pretrained_model.wrapped_model.devices,
+                    )[self.wrapped_pretrained_model.wrapped_model.output_device_index]
 
-            encoder_wrapper_class = _EncoderWrapper
-
-        return encoder_wrapper_class(self)
+        return _EncoderWrapper(self)

--- a/src/tensor_parallel/sharding.py
+++ b/src/tensor_parallel/sharding.py
@@ -15,7 +15,7 @@ from tensor_parallel.cross_device_ops import all_gather
 logger = logging.getLogger(__file__)
 
 
-class Zero3(nn.Module):
+class Sharded(nn.Module):
     def __init__(
         self,
         module,
@@ -35,7 +35,7 @@ class Zero3(nn.Module):
         if replicated_param_names is None:
             if any([p.device.type == "meta" for p in module.parameters()]):
                 raise RuntimeError(
-                    "Trying to shard a model containing 'meta' parameters. Please set `use_zero3=False` during model creation and call `.apply_zero3()` only after dispatch"
+                    "Trying to shard a model containing 'meta' parameters. Please set `sharded=False` during model creation and call `.apply_sharding()` only after dispatch"
                 )
 
             all_param_names = set(name for name, _ in module_shards[0].named_parameters())

--- a/src/tensor_parallel/slicing_configs.py
+++ b/src/tensor_parallel/slicing_configs.py
@@ -213,7 +213,7 @@ def get_gpt2_config(model_config: GPT2Config, devices: Sequence[torch.device]) -
         },
         output_rules={
             r".*[0-9]\.attn$": {0: "sum", 1: gather_kv_across_ranks},
-            r".*mlp$$": {0: "sum"},
+            r".*mlp$": {0: "sum"},
             r".*wte$": {0: "gather -1"},
             r".*wpe$": {0: "gather -1"},
             r".*lm_head$": {0: "sum"},

--- a/src/tensor_parallel/tensor_parallel.py
+++ b/src/tensor_parallel/tensor_parallel.py
@@ -18,7 +18,7 @@ from tensor_parallel.config import TENSOR_PARALLEL_USE_NATIVE, Config, add_lora_
 from tensor_parallel.cross_device_ops import broadcast_coalesced
 from tensor_parallel.shard import make_shard
 from tensor_parallel.utils import nested_flatten, nested_pack
-from tensor_parallel.zero3 import Sharded
+from tensor_parallel.zero3 import Zero3
 
 logger = logging.getLogger(__file__)
 
@@ -117,7 +117,7 @@ class TensorParallel(nn.Module):
                 "Trying to apply ZeRO-3 for the second time. If you wish not to apply ZeRO-3 during model initialization, pass `use_zero3=False`."
             )
         else:
-            self.zero3 = Sharded(self, len(self.devices), replicated_param_names)
+            self.zero3 = Zero3(self, len(self.devices), replicated_param_names)
 
     def prepare_args_kwargs_for_forward(self, *args, **kwargs):
         args_and_kwargs = (args, kwargs)

--- a/src/tensor_parallel/tensor_parallel.py
+++ b/src/tensor_parallel/tensor_parallel.py
@@ -70,10 +70,15 @@ class TensorParallel(nn.Module):
         config_with_ops = tensor_parallel_config.create_collective_ops(self.devices, distributed)
         # ^-- creates a copy of comfig with collective op instances, such as AllReduce and AllGather
 
+        self.modified_parameters_names = set()
         for rank, device in enumerate(self.devices):
             if delay_init:
                 device = torch.device("cpu")
-            self.module_shards.append(make_shard(module, device, config_with_ops, rank=rank, world_size=world_size))
+            shard, modified_parameters_names = make_shard(
+                module, device, config_with_ops, rank=rank, world_size=world_size
+            )
+            self.module_shards.append(shard)
+            self.modified_parameters_names.update(modified_parameters_names)
 
         # self-diagnostics: check if the model was sharded properly
 

--- a/src/tensor_parallel/zero3.py
+++ b/src/tensor_parallel/zero3.py
@@ -15,7 +15,7 @@ from tensor_parallel.cross_device_ops import all_gather
 logger = logging.getLogger(__file__)
 
 
-class Sharded(nn.Module):
+class Zero3(nn.Module):
     def __init__(
         self,
         module,

--- a/src/tensor_parallel/zero3.py
+++ b/src/tensor_parallel/zero3.py
@@ -35,7 +35,7 @@ class Sharded(nn.Module):
         if replicated_param_names is None:
             if any([p.device.type == "meta" for p in module.parameters()]):
                 raise RuntimeError(
-                    "Trying to shard a model containing data on 'meta' device without providing 'sharded_param_names'. Consider sharding a model after loading the data for automatic sharding."
+                    "Trying to shard a model containing 'meta' parameters. Please set `use_zero3=False` during model creation and call `.apply_zero3()` only after dispatch"
                 )
 
             all_param_names = set(name for name, _ in module_shards[0].named_parameters())

--- a/src/tensor_parallel/zero3.py
+++ b/src/tensor_parallel/zero3.py
@@ -27,6 +27,7 @@ class Sharded(nn.Module):
         value is only present on a single device.
         """
         super().__init__()
+        self.preserve_shards_when_saving: bool = True
 
         module_shards = module.module_shards
         if len(module_shards) == 1:
@@ -65,8 +66,6 @@ class Sharded(nn.Module):
                     submodule._parameters.pop(param_name, None)
                     setattr(submodule, param_name, None)
         self._last_versions = None  # to be updated during first forward
-
-        self.preserve_shards_when_saving: bool = True
 
     def synchronize_weights(self, all_cuda: bool):
         shard_versions = tuple(flat_shard._version for flat_shard in self.flat_shards)

--- a/src/tensor_parallel/zero3.py
+++ b/src/tensor_parallel/zero3.py
@@ -4,35 +4,29 @@ Utility functions for training original model parameters
 import functools
 import logging
 import os
-from collections import OrderedDict
-from operator import attrgetter
-from typing import Collection, Dict, List, Optional, Sequence, Set, Tuple
+from typing import Collection, Dict, List, Optional, Sequence, Tuple
 
 import torch
 from torch import nn
 
-from tensor_parallel.config import TENSOR_PARALLEL_USE_NATIVE, get_parameter_name_mapping
+from tensor_parallel.config import TENSOR_PARALLEL_USE_NATIVE
 from tensor_parallel.cross_device_ops import all_gather
-from tensor_parallel.tensor_parallel import TensorParallel
 
 logger = logging.getLogger(__file__)
 
 
-class Sharded(nn.ModuleList):
+class Sharded(nn.Module):
     def __init__(
         self,
-        module: TensorParallel,
+        module,
+        world_size: int,
         replicated_param_names: Optional[Collection[str]] = None,
-        ranks: Optional[Sequence[int]] = None,
-        world_size: Optional[int] = None,
     ):
         """
         Wrap a TensorParallel module and partition the specified param_names between shards so that every parameter
         value is only present on a single device.
         """
         super().__init__()
-        assert isinstance(module, TensorParallel), "expected TensorParallel module"
-        self.module = module
 
         module_shards = module.module_shards
         if len(module_shards) == 1:
@@ -51,15 +45,13 @@ class Sharded(nn.ModuleList):
             logger.warning("Did not find any parameters to shard")
             return
 
-        self.ranks = ranks = tuple(ranks if ranks is not None else range(len(module_shards)))
-        assert ranks == tuple(sorted(ranks)), "ranks (and module shards) must be ordered from lowest to highest rank"
         self.world_size = world_size = world_size if world_size is not None else len(module_shards)
         sharded_param_names_set = set(replicated_param_names)
         all_param_shapes = {
             name: param.shape for name, param in module_shards[0].named_parameters() if name in sharded_param_names_set
         }
         self._sharded_param_shapes = [all_param_shapes[name] for name in replicated_param_names]
-        flat_shards, shard_sizes_with_pad = _make_flat_shards(replicated_param_names, module_shards, ranks, world_size)
+        flat_shards, shard_sizes_with_pad = _make_flat_shards(replicated_param_names, module_shards, world_size)
         self.flat_shards = nn.ParameterList(list(map(nn.Parameter, flat_shards)))
         self._shard_sizes_with_pad = shard_sizes_with_pad
 
@@ -74,36 +66,17 @@ class Sharded(nn.ModuleList):
                     setattr(submodule, param_name, None)
         self._last_versions = None  # to be updated during first forward
 
-    @property
-    def devices(self):
-        return self.module.devices
+        self.preserve_shards_when_saving: bool = True
 
-    @property
-    def tensor_parallel_config(self):
-        return self.module.tensor_parallel_config
-
-    @property
-    def preserve_shards_when_saving(self):
-        return self.module.preserve_shards_when_saving
-
-    @preserve_shards_when_saving.setter
-    def preserve_shards_when_saving(self, value):
-        self.module.preserve_shards_when_saving = value
-
-    def forward(self, *args, **kwargs):
-        if len(self.module.module_shards) > 1 and len(self.sharded_param_names) > 0:
-            self._maybe_fill_sharded_params()
-        return self.module(*args, **kwargs)
-
-    def _maybe_fill_sharded_params(self):
+    def synchronize_weights(self, all_cuda: bool):
         shard_versions = tuple(flat_shard._version for flat_shard in self.flat_shards)
         if shard_versions == self._last_versions:
             logger.debug("Using previously gathered parameters")
             return  # parameters did not change since last all-gather; keep old versions
 
         logger.debug("Gathering sharded parameters")
-        gathered_shards = all_gather(list(self.flat_shards), all_cuda=self.module.all_cuda)
-        for rank, flat_shards, param_occurences in zip(self.ranks, gathered_shards, self.param_occurences_by_rank):
+        gathered_shards = all_gather(list(self.flat_shards), all_cuda=all_cuda)
+        for flat_shards, param_occurences in zip(gathered_shards, self.param_occurences_by_rank):
             combined_params = _combine_shards(flat_shards, self._shard_sizes_with_pad, self._sharded_param_shapes)
             assert len(combined_params) == len(param_occurences)
             for new_value, occurences in zip(combined_params, param_occurences):
@@ -111,33 +84,11 @@ class Sharded(nn.ModuleList):
                     setattr(submodule, param_name, new_value)
         self._last_versions = tuple(flat_shard._version for flat_shard in self.flat_shards)
 
-    def state_dict(self, destination=None, prefix="", keep_vars=False):
-        if self.module.preserve_shards_when_saving:
-            return super().state_dict(destination=destination, prefix=prefix, keep_vars=keep_vars)
-        if destination is None:
-            destination = OrderedDict()
-            destination._metadata = OrderedDict()
-
-        local_metadata = dict(version=self._version)
-        if hasattr(destination, "_metadata"):
-            destination._metadata[prefix[:-1]] = local_metadata
-
-        self._maybe_fill_sharded_params()
-
-        for name in self.sharded_param_names:
-            for shard in self.module.module_shards:
-                try:
-                    destination[prefix + name] = attrgetter(name)(shard)
-                    break
-                except KeyError:
-                    pass
-
-        state_dict = self.module.state_dict(destination=destination, prefix=prefix, keep_vars=keep_vars)
-        return state_dict
-
-    @property
-    def module_shards(self):
-        return self.module.module_shards
+    def state_dict(self, *args, **kwargs):
+        if self.preserve_shards_when_saving:
+            return super().state_dict(*args, **kwargs)
+        else:
+            return kwargs["destination"]
 
 
 @torch.no_grad()
@@ -184,24 +135,24 @@ def _find_all_occurences(model: nn.Module, param_names: Sequence[str]) -> Sequen
 
 @torch.no_grad()
 def _make_flat_shards(
-    sharded_param_names: Sequence[str], module_shards: Sequence[nn.Module], ranks: Sequence[int], world_size: int
+    sharded_param_names: Sequence[str], module_shards: Sequence[nn.Module], world_size: int
 ) -> Tuple[List[torch.Tensor], List[List[int]]]:
     """Create 1d buffers containing all parameter shards for each rank, return buffers and the original shard sizes"""
     extracted_shards = {
-        rank: _extract_param_shards(shard, sharded_param_names, rank=rank, world_size=world_size)
-        for rank, shard in zip(ranks, module_shards)
+        i: _extract_param_shards(shard, sharded_param_names, rank=i, world_size=world_size)
+        for i, shard in enumerate(module_shards)
     }
     shard_sizes = {rank: [shard.numel() for shard in shards] for rank, shards in extracted_shards.items()}
     shard_totals = {rank: sum(numel) for rank, numel in shard_sizes.items()}
     max_size = max(shard_totals.values())
     paddings = {rank: max_size - shard_size for rank, shard_size in shard_totals.items()}
-    shard_sizes_with_pad = [shard_sizes[rank] + [paddings[rank]] for rank in ranks]
+    shard_sizes_with_pad = [shard_sizes[i] + [paddings[i]] for i in range(len(module_shards))]
 
     padding_tensors = {
         rank: torch.zeros(paddings[rank], device=shards[0].device, dtype=shards[0].dtype)
         for rank, shards in extracted_shards.items()
     }
-    flat_shards = [torch.cat(extracted_shards[rank] + [padding_tensors[rank]]) for rank in ranks]
+    flat_shards = [torch.cat(extracted_shards[i] + [padding_tensors[i]]) for i in range(len(module_shards))]
     assert len(set(len(flat_shard) for flat_shard in flat_shards)) == 1
     return flat_shards, shard_sizes_with_pad
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -6,7 +6,7 @@ import torch.nn as nn
 from torch.nn.modules.conv import _ConvTransposeNd
 
 import tensor_parallel
-from tensor_parallel import Config, Sharded, TensorParallel
+from tensor_parallel import Config, TensorParallel
 
 
 @pytest.mark.parametrize("emb_cls", [nn.Embedding, nn.EmbeddingBag])
@@ -21,6 +21,7 @@ def test_basic_attributes(emb_cls, devices):
             nn.Linear(128, 10),
         ),
         device_ids=devices,
+        use_zero3=False,
     )
 
     for name, module in model_tp.named_modules():
@@ -29,8 +30,9 @@ def test_basic_attributes(emb_cls, devices):
 
 
 @pytest.mark.parametrize("emb_cls", [nn.Embedding, nn.EmbeddingBag])
+@pytest.mark.parametrize("use_zero3", [False, True])
 @pytest.mark.parametrize("devices", [None, ("cpu",), ("cpu", "cpu"), ("cpu", "cpu", "cpu")])
-def test_embeds_and_linear(emb_cls, devices):
+def test_embeds_and_linear(emb_cls, use_zero3, devices):
     torch.manual_seed(0)
 
     model = nn.Sequential(
@@ -46,7 +48,7 @@ def test_embeds_and_linear(emb_cls, devices):
     ref_out.norm().backward()
 
     model_tp = deepcopy(model)  # deepcopy to avoid accidental grad spillage and false positives
-    model_tp = TensorParallel(model_tp, device_ids=devices)
+    model_tp = TensorParallel(model_tp, device_ids=devices, use_zero3=use_zero3)
     out_ours = model_tp(inputs)
     out_ours.norm().backward()
     torch.testing.assert_close(ref_out, out_ours, atol=1e-6, rtol=1e-05)
@@ -55,8 +57,9 @@ def test_embeds_and_linear(emb_cls, devices):
 
 
 @pytest.mark.parametrize("devices", [None, ("cpu",), ("cpu",) * 2, ("cpu",) * 3, ("cpu",) * 4])
+@pytest.mark.parametrize("use_zero3", [False, True])
 @pytest.mark.parametrize("extra_options", [{}, {"padding": "same"}, {"stride": 2}, {"dilation": 2}, {"groups": 2}])
-def test_convs(devices, extra_options):
+def test_convs(devices, use_zero3, extra_options):
     torch.manual_seed(0)
 
     batchnorm_cls = (None, nn.BatchNorm1d, nn.BatchNorm2d, nn.BatchNorm3d)
@@ -83,7 +86,7 @@ def test_convs(devices, extra_options):
         ref_out.norm().backward()
 
         model_tp = deepcopy(model)  # deepcopy to avoid accidental grad spillage and false positives
-        model_tp = TensorParallel(model_tp, device_ids=devices)
+        model_tp = TensorParallel(model_tp, device_ids=devices, use_zero3=use_zero3)
         out_ours = model_tp(inputs2)
         out_ours.norm().backward()
         torch.testing.assert_close(
@@ -104,7 +107,7 @@ def test_convs(devices, extra_options):
 
 @pytest.mark.parametrize("emb_cls", [nn.Embedding, nn.EmbeddingBag])
 @pytest.mark.parametrize("devices", [None, ("cpu",), ("cpu", "cpu"), ("cpu", "cpu", "cpu")])
-def test_sharding(emb_cls, devices):
+def test_zero3_num_params(emb_cls, devices):
     torch.manual_seed(0)
 
     model = nn.Sequential(
@@ -121,21 +124,15 @@ def test_sharding(emb_cls, devices):
     ref_out.norm().backward()
 
     model_tp = deepcopy(model)  # deepcopy to avoid accidental grad spillage and false positives
-    model_tp = TensorParallel(model_tp, device_ids=devices)
+    model_tp = TensorParallel(model_tp, device_ids=devices, use_zero3=False)
     world_size = len(model_tp.module_shards)
     num_params_tp = sum(p.numel() for p in model_tp.parameters())
-    model_tp = Sharded(model_tp)
+    model_tp.apply_zero3()
     num_params_sharded = sum(p.numel() for p in model_tp.parameters())
     assert num_params_sharded < num_params_tp or world_size == 1
 
     padding_params = 0 if world_size < 3 else 4
     assert num_params_sharded == num_params_original + padding_params
-
-    out_ours = model_tp(inputs)
-    out_ours.norm().backward()
-    torch.testing.assert_close(ref_out, out_ours, atol=1e-6, rtol=1e-05)
-    our_grad = torch.cat([next(shard[0].parameters()).grad for shard in model_tp.module.module_shards], dim=1)
-    torch.testing.assert_close(model[0].weight.grad, our_grad, atol=1e-6, rtol=1e-05)
 
 
 @pytest.mark.parametrize("devices", [("cpu", "cpu"), ("cpu", "cpu", "cpu")])

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -5,8 +5,8 @@ import transformers
 from tensor_parallel import TensorParallel, tensor_parallel
 
 
-@pytest.mark.parametrize("sharded", [True, False])
-def test_factory_nn_module(sharded):
+@pytest.mark.parametrize("use_zero3", [True, False])
+def test_factory_nn_module(use_zero3):
     model = nn.Sequential(
         nn.Embedding(num_embeddings=1337, embedding_dim=64),
         nn.LayerNorm(64),
@@ -16,9 +16,9 @@ def test_factory_nn_module(sharded):
     )
 
     assert isinstance(model, nn.Module)
-    model = tensor_parallel(model, device_ids=["cpu", "cpu"], sharded=sharded)
+    model = tensor_parallel(model, device_ids=["cpu", "cpu"], use_zero3=use_zero3)
     assert isinstance(model, TensorParallel)
-    assert (model.zero3 is None) != sharded
+    assert (model.zero3 is None) != use_zero3
 
 
 def test_factory_pretrainedmodel():

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -17,7 +17,8 @@ def test_factory_nn_module(sharded):
 
     assert isinstance(model, nn.Module)
     model = tensor_parallel(model, device_ids=["cpu", "cpu"], sharded=sharded)
-    assert isinstance(model, TensorParallel) if not sharded else isinstance(model.module, TensorParallel)
+    assert isinstance(model, TensorParallel)
+    assert (model.zero3 is None) != sharded
 
 
 def test_factory_pretrainedmodel():

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -5,8 +5,8 @@ import transformers
 from tensor_parallel import TensorParallel, tensor_parallel
 
 
-@pytest.mark.parametrize("use_zero3", [True, False])
-def test_factory_nn_module(use_zero3):
+@pytest.mark.parametrize("sharded", [True, False])
+def test_factory_nn_module(sharded):
     model = nn.Sequential(
         nn.Embedding(num_embeddings=1337, embedding_dim=64),
         nn.LayerNorm(64),
@@ -16,9 +16,9 @@ def test_factory_nn_module(use_zero3):
     )
 
     assert isinstance(model, nn.Module)
-    model = tensor_parallel(model, device_ids=["cpu", "cpu"], use_zero3=use_zero3)
+    model = tensor_parallel(model, device_ids=["cpu", "cpu"], sharded=sharded)
     assert isinstance(model, TensorParallel)
-    assert (model.zero3 is None) != use_zero3
+    assert (model.sharding_manager is None) != sharded
 
 
 def test_factory_pretrainedmodel():

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -7,7 +7,7 @@ from tensor_parallel import Sharded, tensor_parallel
 def test_legacy_factory_and_sharded():
     model = BertModel.from_pretrained("bert-base-uncased")
 
-    tp_model = tensor_parallel(model, sharded=False)
+    tp_model = tensor_parallel(model, device_ids=["cpu", "cpu"], sharded=False)
     assert isinstance(tp_model, PreTrainedModel)
     tp_model.wrapped_model = Sharded(tp_model.wrapped_model)
 

--- a/tests/test_saving.py
+++ b/tests/test_saving.py
@@ -86,7 +86,8 @@ def test_parallelism_zero_3(devices, model_name):
 
 @pytest.mark.parametrize("devices", [("cpu",) * 2, ("cpu",) * 3])
 @pytest.mark.parametrize(
-    "model_name", ["bert-base-uncased", "hf-internal-testing/tiny-random-t5", "hf-internal-testing/tiny-random-bloom"]
+    "model_name",
+    ["bert-base-uncased", "hf-internal-testing/tiny-random-t5", "hf-internal-testing/tiny-random-BloomModel"],
 )
 @pytest.mark.parametrize("shard_as_pretrained", [True, False])
 def test_save_keep_shards(devices, model_name, shard_as_pretrained):
@@ -106,11 +107,11 @@ def get_tensor_parallel(model: torch.nn.Module, devices, pretrained: bool, zero3
         return TensorParallel(model, devices, use_zero3=zero3)
 
 
-@pytest.mark.parametrize("devices", [("cpu",) * 2, ("cpu",) * 3])
-@pytest.mark.parametrize("model_name", ["bert-base-uncased", "hf-internal-testing/tiny-random-bloom"])
-@pytest.mark.parametrize("pretrained", [True, False])
-@pytest.mark.parametrize("zero3", [True, False])
-@pytest.mark.parametrize("meta", [True, False])
+@pytest.mark.parametrize("devices", [("cpu",) * 2])
+@pytest.mark.parametrize("model_name", ["hf-internal-testing/tiny-random-BloomModel"])
+@pytest.mark.parametrize("pretrained", [True])
+@pytest.mark.parametrize("zero3", [True])
+@pytest.mark.parametrize("meta", [False])
 def test_save_shards_load_shards(devices, model_name, pretrained, zero3, meta):
     devices = [torch.device(device) for device in devices]
 

--- a/tests/test_saving.py
+++ b/tests/test_saving.py
@@ -144,8 +144,8 @@ def test_save_shards_load_shards(devices, model_name, pretrained, zero3, meta):
     model_tp(torch.zeros(1, 8, dtype=int))
 
 
-@pytest.mark.parametrize("use_pretrained", [True])
-@pytest.mark.parametrize("devices", [("cpu",) * 2])
+@pytest.mark.parametrize("use_pretrained", [False, True])
+@pytest.mark.parametrize("devices", [("cpu",) * 2, ("cpu",) * 3])
 @pytest.mark.parametrize("model_name", ["bert-base-uncased"])
 def test_convert_state_dict(use_pretrained, devices, model_name):
     model = AutoModel.from_pretrained(model_name)

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -262,11 +262,10 @@ def test_generate(generate_kwargs, model_name, use_zero3, devices):
     _assert_scores_allclose_long_enough(scores_ref, scores)
 
 
-@pytest.mark.parametrize("use_predefined_config", [False, True])
 @pytest.mark.parametrize("model_name", ["t5-small"])
 @pytest.mark.parametrize("use_zero3", [False, True])
 @pytest.mark.parametrize("devices", [("cpu",) * 2, ("cpu",) * 3])
-def test_encoder(use_predefined_config, model_name, use_zero3, devices):
+def test_encoder(model_name, use_zero3, devices):
     torch.manual_seed(0)
 
     model = T5ForConditionalGeneration.from_pretrained(model_name, low_cpu_mem_usage=True)
@@ -277,8 +276,6 @@ def test_encoder(use_predefined_config, model_name, use_zero3, devices):
     out1_ref = model.get_encoder()(inp1)
     out2_ref = model.get_encoder()(inp2)
 
-    if not use_predefined_config:
-        model.config.architectures = ["Pretend we don't know this architecture"]
     model_tp = TensorParallelPreTrainedModel(model, devices, use_zero3=use_zero3)
     assert isinstance(model_tp, TensorParallelPreTrainedModel)
     del model

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -298,7 +298,7 @@ def test_generate_inputs_embeds(model_name, devices):
 
     scores_ref = _generate_scores(model, inputs_embeds)
 
-    model_tp = tensor_parallel(model, devices)
+    model_tp = TensorParallelPreTrainedModel(model, devices)
     del model
 
     scores = _generate_scores(model_tp, inputs_embeds)


### PR DESCRIPTION
A huge refactoring of `Sharded`:
1) `Sharded` is now a sub-module of `TensorParallel`, not a wrapper. `Sharded` is not supposed to be interfaced with by end user.
2) `TensorParallel` now keeps track of which parameters were modified to pass this list to `Sharded`. This removes the need to find replicated parameters by hand since all those that were not modified are replicated.
3) `Sharded` is marked for deprecation, but a backwards compatibility placeholder is implemented.

Tests modifications:
1) All the _basic_ tests now also test with `Zero3`.
2) All the _transformers_ tests now also test with `Zero3`.
3) Better `dispatch` tests to test for specific use-cases.

Questionable choices:
1) `Zero3` now depends on `get_parameter_name_mapping` which utilizes config **regex**.  Regex is always unreliable. Might need to find a better solution.
