### PR TITLE
Fix get_llama_config adding model attribute error. 

### DIFF
--- a/src/tensor_parallel/slicing_configs.py
+++ b/src/tensor_parallel/slicing_configs.py
@@ -5,10 +5,10 @@ cases, e.g. training with very small batches or inference with long sequences.
 NB: some of these configs get fairly complicated in order to squeeze a bit of extra performance. When developing your
   own config, you can get most of the performance benefits by using auto config -- and maybe splitting MLP layers.
 """
+import re
 from functools import partial
 from itertools import chain
 from typing import Callable, Dict, Sequence
-import re
 import torch
 from transformers import BertConfig, BloomConfig, CodeGenConfig, GPT2Config, GPTNeoXConfig, PretrainedConfig, T5Config
 
@@ -397,8 +397,10 @@ def get_llama_config(model_config: PretrainedConfig, devices: Sequence[torch.dev
         },
     )
 
-    if new_modeling:        
-        config.attr_rules[re.compile('.*self_attn$')]["num_key_value_heads"] = partial(split_num_heads, world_size=world_size)
+    if new_modeling:
+        config.attr_rules[re.compile(".*self_attn$")]["num_key_value_heads"] = partial(
+            split_num_heads, world_size=world_size
+        )
 
     return config
 

--- a/src/tensor_parallel/slicing_configs.py
+++ b/src/tensor_parallel/slicing_configs.py
@@ -9,6 +9,7 @@ import re
 from functools import partial
 from itertools import chain
 from typing import Callable, Dict, Sequence
+
 import torch
 from transformers import BertConfig, BloomConfig, CodeGenConfig, GPT2Config, GPTNeoXConfig, PretrainedConfig, T5Config
 

--- a/src/tensor_parallel/slicing_configs.py
+++ b/src/tensor_parallel/slicing_configs.py
@@ -8,7 +8,7 @@ NB: some of these configs get fairly complicated in order to squeeze a bit of ex
 from functools import partial
 from itertools import chain
 from typing import Callable, Dict, Sequence
-
+import re
 import torch
 from transformers import BertConfig, BloomConfig, CodeGenConfig, GPT2Config, GPTNeoXConfig, PretrainedConfig, T5Config
 
@@ -397,8 +397,8 @@ def get_llama_config(model_config: PretrainedConfig, devices: Sequence[torch.dev
         },
     )
 
-    if new_modeling:
-        config.attr_rules[r".*self_attn$"]["num_key_value_heads"] = partial(split_num_heads, world_size=world_size)
+    if new_modeling:        
+        config.attr_rules[re.compile('.*self_attn$')]["num_key_value_heads"] = partial(split_num_heads, world_size=world_size)
 
     return config
 


### PR DESCRIPTION
Fix #107 KeyError when add new attr_rules.

Before: 
```python
config.attr_rules: {re.compile('.*self_attn$'): {'hidden_size': functools.partial(<function split_inner_dim at 0x7f38e434dfc0>, num_heads=64, world_size=2), 'num_heads': <function get_llama_config.<locals>.<lambda> at 0x7f39a9662200>}}
``` 
After fix key/value num_key_value_heads is added
```python
config.attr_rules: {re.compile('.*self_attn$'): {'hidden_size': functools.partial(<function split_inner_dim at 0x7f38e434dfc0>, num_heads=64, world_size=2), 'num_heads': <function get_llama_config.<locals>.<lambda> at 0x7f39a9662200>, 'num_key_value_heads': functools.partial(<function split_num_heads at 0x7f38e434df30>, world_size=2)}}
``` 