### PR TITLE
fix recursion error when setting tp_wrapped_module #122

### DIFF
--- a/src/tensor_parallel/wrapper.py
+++ b/src/tensor_parallel/wrapper.py
@@ -73,3 +73,8 @@ class TensorParallelWrapper(nn.Module):
 
     def __getattr__(self, attr):
         return getattr(self.tp_wrapped_module, attr)
+
+    def __setattr__(self, attr, value):
+        super().__setattr__(attr, value)
+        if attr == "tp_wrapped_module":
+            self.__dict__["tp_wrapped_module"] = value  # to access without getattr, nn.Module removed it from __dict__


### PR DESCRIPTION
To fix the error mentioned in #122 
This happens whenever the attribute `tp_wrapped_module` is changed (for example inside LoRA or other PEFT methods)

I am not 100% sure this works as I have not started training yet but it has certainly made my example in #122 work as expected.